### PR TITLE
feat:Basic CI for api

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -1,4 +1,4 @@
-name: Frontend CI
+name: API CI
 
 on:
   push:

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -21,7 +21,7 @@ jobs:
         image: mongo:latest
         ports:
           - 27017:27017
-        options: > 
+        options: |
           --health-cmd="mongo --eval 'db.runCommand({ ping: 1 })'" 
           --health-interval=10s
           --health-timeout=5s

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -21,12 +21,7 @@ jobs:
         image: mongo:latest
         ports:
           - 27017:27017
-        options: |
-          --health-cmd="mongo --eval 'db.runCommand({ ping: 1 })'" 
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-
+  
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -16,6 +16,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    services:
+      mongo:
+        image: mongo:latest
+        ports:
+          - 27017:27017
+        options: > 
+          --health-cmd "mongo --eval 'db.runCommand({ ping: 1 })'" 
+          --health-interval 10s 
+          --health-timeout 5s 
+          --health-retries 5
+
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -24,7 +35,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20.x'
-        # cache: 'npm'
       
     - name: Install Dependencies
       run: npm ci

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -1,0 +1,36 @@
+name: Frontend CI
+
+on:
+  push:
+    branches: 
+      - "main"
+      - "develop"
+  pull_request:
+    branches:
+      - "main"
+      - "develop"
+  workflow_dispatch: 
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Install Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20.x'
+        # cache: 'npm'
+      
+    - name: Install Dependencies
+      run: npm ci
+      working-directory: ./api
+   
+    - name: Run Tests	
+      run: npm test
+      working-directory: ./api
+

--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -22,10 +22,10 @@ jobs:
         ports:
           - 27017:27017
         options: > 
-          --health-cmd "mongo --eval 'db.runCommand({ ping: 1 })'" 
-          --health-interval 10s 
-          --health-timeout 5s 
-          --health-retries 5
+          --health-cmd="mongo --eval 'db.runCommand({ ping: 1 })'" 
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
 
     steps:
     - name: Checkout Repository


### PR DESCRIPTION
## Description

I first used the same script from my frontend CI minus the build step but afterwards realised that the backend tests require a database. I found out that you can actually create a database instance with GitHub actions which I believe pulls a Docker image of MongoDB. 