### PR TITLE
18 fix jwt implementation

### DIFF
--- a/api/.env.test
+++ b/api/.env.test
@@ -1,2 +1,3 @@
 MONGODB_URL="mongodb://0.0.0.0/RecipEasy_test"
 JWT_SECRET=test_secret
+REFRESH_TOKEN_SECRET="test_secret"

--- a/api/app.js
+++ b/api/app.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const bodyParser = require("body-parser");
+const cookieParser = require("cookie-parser");
 const cors = require("cors");
 
 const usersRouter = require("./routes/users");
@@ -16,6 +17,8 @@ app.use(cors());
 
 // Parse JSON request bodies, made available on `req.body`
 app.use(bodyParser.json());
+
+app.use(cookieParser()); 
 
 // API Routes
 app.use("/users", usersRouter);

--- a/api/controllers/authentication.js
+++ b/api/controllers/authentication.js
@@ -2,21 +2,37 @@ const User = require("../models/user");
 const { generateToken } = require("../lib/token");
 
 const createToken = async (req, res) => {
-  const email = req.body.email;
-  const password = req.body.password;
+  const { username, password } = req.body;
 
-  const user = await User.findOne({ email: email });
+  if (!username || !password) {
+    return res.status(400).json({ message: "All login fields are required." });
+  }
+
+  const user = await User.findOne({ username: username }).exec();
+
   if (!user) {
     console.log("Auth Error: User not found");
-    res.status(401).json({ message: "User not found" });
-  } else if (user.password !== password) {
-    console.log("Auth Error: Passwords do not match");
-    res.status(401).json({ message: "Password incorrect" });
-  } else {
-    const token = generateToken(user.id);
-    res.status(201).json({ token: token, message: "OK" });
+    return res
+      .status(401)
+      .json({ message: "Please check your login details." });
   }
+
+  if (user.password !== password) {
+    console.log("Auth Error: Passwords do not match");
+    return res
+      .status(401)
+      .json({ message: "Please check your login details." });
+  }
+
+  const token = generateToken(user.id);
+  res.status(201).json({ token: token, message: "OK" });
 };
+
+const refresh = async (req, res) => {};
+
+const logOut = async (req, res) => {};
+
+//I THINK THIS IS UNECESSARY
 //TODO: Needs a simple test for this
 // uses token checker to test if a token is valid
 const checkToken = async (req, res) => {

--- a/api/controllers/authentication.js
+++ b/api/controllers/authentication.js
@@ -1,5 +1,5 @@
 const User = require("../models/user");
-const { generateToken } = require("../lib/token");
+const { generateToken, generateRefreshToken } = require("../lib/token");
 
 const createToken = async (req, res) => {
   const { username, password } = req.body;
@@ -24,8 +24,17 @@ const createToken = async (req, res) => {
       .json({ message: "Please check your login details." });
   }
 
-  const token = generateToken(user.id);
-  res.status(201).json({ token: token, message: "OK" });
+  const accessToken = generateToken(user.id);
+  const refreshToken = generateRefreshToken(user.id);
+
+  res.cookie("jwt", refreshToken, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "None",
+    maxAge: 7 * 24 * 60 * 60 * 1000,
+  });
+
+  res.status(201).json({ token: accessToken, message: "OK" });
 };
 
 const refresh = async (req, res) => {};

--- a/api/controllers/authentication.js
+++ b/api/controllers/authentication.js
@@ -65,7 +65,12 @@ const refresh = async (req, res) => {
   }
 };
 
-const logOut = async (req, res) => {};
+const logOut = async (req, res) => {
+  const cookies = req.cookies;
+  if (!cookies?.jwt) return res.sendStatus(204);
+  res.clearCookie("jwt", { httpOnly: true, secure: true, sameSite: "None" });
+  res.status(200).json({ message: "Cookie cleared" });
+};
 
 //I THINK THIS IS UNECESSARY
 //TODO: Needs a simple test for this
@@ -82,8 +87,9 @@ const checkToken = async (req, res) => {
 
 const AuthenticationController = {
   createToken,
-  checkToken,
   refresh,
+  logOut, 
+  checkToken,
 };
 
 module.exports = AuthenticationController;

--- a/api/controllers/users.js
+++ b/api/controllers/users.js
@@ -47,6 +47,7 @@ const login = async (req, res) => {
   }
 };
 
+//TODO: CAN DELETE as JWT implementation has changed
 const logout = (req, res) => {
   res.status(200).json({ message: "Logout successful" });
 };

--- a/api/lib/token.js
+++ b/api/lib/token.js
@@ -11,11 +11,9 @@ const generateToken = (user_id) => {
     {
       user_id: user_id,
       iat: Math.floor(Date.now() / 1000),
-
-      // Set the JWT token to expire in 10 minutes
-      exp: Math.floor(Date.now() / 1000) + 10 * 60,
     },
-    secret
+    secret, 
+    {expiresIn: '10m'}
   );
 };
 

--- a/api/lib/token.js
+++ b/api/lib/token.js
@@ -14,7 +14,7 @@ const generateToken = (user_id) => {
       iat: Math.floor(Date.now() / 1000),
     },
     secret,
-    { expiresIn: "10s" }
+    { expiresIn: "10m" }
   );
 };
 

--- a/api/lib/token.js
+++ b/api/lib/token.js
@@ -18,7 +18,7 @@ const generateToken = (user_id) => {
   );
 };
 
-const refreshToken = (user_id) => {
+const generateRefreshToken = (user_id) => {
   return JWT.sign(
     {
       user_id: user_id,
@@ -33,4 +33,4 @@ const decodeToken = (token) => {
   return JWT.decode(token, secret);
 };
 
-module.exports = { generateToken, decodeToken };
+module.exports = { generateToken, generateRefreshToken, decodeToken };

--- a/api/lib/token.js
+++ b/api/lib/token.js
@@ -7,7 +7,7 @@ const refreshTokenSecret = process.env.REFRESH_TOKEN_SECRET;
  * token for a specific user.
  * JWTs in 100 Seconds: https://www.youtube.com/watch?v=UBUNrFtufWo
  */
-const generateToken = (user_id) => {
+const generateToken = (user_id) => { 
   return JWT.sign(
     {
       user_id: user_id,
@@ -22,7 +22,7 @@ const generateRefreshToken = (user_id) => {
   return JWT.sign(
     {
       user_id: user_id,
-      iat: Math.floow(Date.now() / 1000),
+      iat: Math.floor(Date.now() / 1000),
     },
     refreshTokenSecret,
     { expiresIn: "1d" }

--- a/api/lib/token.js
+++ b/api/lib/token.js
@@ -1,5 +1,6 @@
 const JWT = require("jsonwebtoken");
 const secret = process.env.JWT_SECRET;
+const refreshTokenSecret = process.env.REFRESH_TOKEN_SECRET;
 
 /**
  * This function is used to generate a JWT authentication
@@ -12,8 +13,19 @@ const generateToken = (user_id) => {
       user_id: user_id,
       iat: Math.floor(Date.now() / 1000),
     },
-    secret, 
-    {expiresIn: '10m'}
+    secret,
+    { expiresIn: "10s" }
+  );
+};
+
+const refreshToken = (user_id) => {
+  return JWT.sign(
+    {
+      user_id: user_id,
+      iat: Math.floow(Date.now() / 1000),
+    },
+    refreshTokenSecret,
+    { expiresIn: "1d" }
   );
 };
 

--- a/api/middleware/loginLimiter.js
+++ b/api/middleware/loginLimiter.js
@@ -1,0 +1,12 @@
+const rateLimit = require('express-rate-limit'); 
+
+const loginLimiter = rateLimit({
+    windowMs: 60 * 1000, 
+    max: 5, 
+    message: "Too many login attempts from this IP, please try again later.",
+    standardHeaders: true, 
+    legacyHeaders: false, 
+}
+)
+
+module.exports = loginLimiter

--- a/api/middleware/tokenChecker.js
+++ b/api/middleware/tokenChecker.js
@@ -2,23 +2,18 @@ const JWT = require("jsonwebtoken");
 
 // Middleware function to check for valid tokens
 const tokenChecker = (req, res, next) => {
-  let token;
-  const authHeader = req.get("Authorization");
+  const authHeader = req.get("Authorization") || req.get("authorization");
 
-  if (authHeader) {
-    token = authHeader.slice(7);
-  }
+  if (!authHeader?.startsWith("Bearer "))
+    return res.status(401).json({ message: "Unauthorized" });
+
+  const token = authHeader.slice(7);
 
   JWT.verify(token, process.env.JWT_SECRET, (err, payload) => {
-    if (err) {
-      console.log(err);
-      res.status(401).json({ message: "auth error" });
-    } else {
-      // Add the user_id from the payload to the req object.
-      req.user_id = payload.user_id;
-      // console.log(payload)
-      next();
-    }
+    if (err) return res.status(401).json({ message: "Unauthorized" });
+
+    req.user_id = payload.user_id;
+    next();
   });
 };
 

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15,6 +15,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "express-rate-limit": "^7.4.0",
         "iso8601-duration": "^2.1.2",
         "jsonwebtoken": "^9.0.1",
         "mongoose": "^7.4.1",
@@ -1051,18 +1052,18 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.1.0.tgz",
-      "integrity": "sha512-xloWvocjvryHdUjDam/ZuGMh7zn4Sn3ZAaV4Ah2e2EwEt90N3XphZlSsU3n0VDc1F7kggCjMuH0UuxfPQ5mD9w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.3.0.tgz",
+      "integrity": "sha512-ioXoq9gPxkss4MYhD+SFaU9p1IHFUX0ILAWFPyjGaBdjLsYAlZw6j1iLA0N/m12uVHLFDfSYNF7EQccjinIMDA==",
       "dependencies": {
-        "debug": "4.3.4",
-        "extract-zip": "2.0.1",
-        "progress": "2.0.3",
-        "proxy-agent": "6.4.0",
-        "semver": "7.6.0",
-        "tar-fs": "3.0.5",
-        "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.2"
+        "debug": "^4.3.5",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.4.0",
+        "semver": "^7.6.3",
+        "tar-fs": "^3.0.6",
+        "unbzip2-stream": "^1.4.3",
+        "yargs": "^17.7.2"
       },
       "bin": {
         "browsers": "lib/cjs/main-cli.js"
@@ -1072,9 +1073,9 @@
       }
     },
     "node_modules/@puppeteer/browsers/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1257,9 +1258,9 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -1268,9 +1269,9 @@
       }
     },
     "node_modules/agent-base/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1487,36 +1488,44 @@
       "dev": true
     },
     "node_modules/bare-events": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.0.tgz",
-      "integrity": "sha512-Yyyqff4PIFfSuthCZqLlPISTWHmnQxoPuAvkmgzsJEmG3CesdIv6Xweayl0JkCZJSB2yYIdJyEz97tpxNhgjbg==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
+      "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.2.0.tgz",
-      "integrity": "sha512-+VhW202E9eTVGkX7p+TNXtZC4RTzj9JfJW7PtfIbZ7mIQ/QT9uOafQTx7lx2n9ERmWsXvLHF4hStAFn4gl2mQw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.1.tgz",
+      "integrity": "sha512-W/Hfxc/6VehXlsgFtbB5B4xFcsCl+pAh30cYhoFyXErf6oGrwjh8SwiPAdHgpmWonKuYpZgGywN0SXt7dgsADA==",
       "optional": true,
       "dependencies": {
         "bare-events": "^2.0.0",
-        "bare-os": "^2.0.0",
         "bare-path": "^2.0.0",
-        "streamx": "^2.13.0"
+        "bare-stream": "^2.0.0"
       }
     },
     "node_modules/bare-os": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.2.0.tgz",
-      "integrity": "sha512-hD0rOPfYWOMpVirTACt4/nK8mC55La12K5fY1ij8HAdfQakD62M+H4o4tpfKzVGLgRDTuk3vjA4GqGXXCeFbag==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.0.tgz",
+      "integrity": "sha512-v8DTT08AS/G0F9xrhyLtepoo9EJBJ85FRSMbu1pQUlAf6A8T0tEEQGMVObWeqpjhSPXsE0VGlluFBJu2fdoTNg==",
       "optional": true
     },
     "node_modules/bare-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.0.tgz",
-      "integrity": "sha512-DIIg7ts8bdRKwJRJrUMy/PICEaQZaPGZ26lsSx9MJSwIhSrcdHn7/C8W+XmnG/rKi6BaRcz+JO00CjZteybDtw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.3.tgz",
+      "integrity": "sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==",
       "optional": true,
       "dependencies": {
         "bare-os": "^2.1.0"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.1.3.tgz",
+      "integrity": "sha512-tiDAH9H/kP+tvNO5sczyn9ZAA7utrSMobyDchsnyyXBuUe2FSQWbxhtuHB8jwpHYYevVo2UJpcmvvjrbHboUUQ==",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.18.0"
       }
     },
     "node_modules/base64-js": {
@@ -1539,9 +1548,9 @@
       ]
     },
     "node_modules/basic-ftp": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.4.tgz",
-      "integrity": "sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -1585,12 +1594,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1827,12 +1836,13 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.10.tgz",
-      "integrity": "sha512-4hsPE1VaLLM/sgNK/SlLbI24Ra7ZOuWAjA3rhw1lVCZ8ZiUgccS6cL5L/iqo4hjRcl5vwgYJ8xTtbXdulA9b6Q==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.3.tgz",
+      "integrity": "sha512-qXlsCmpCZJAnoTYI83Iu6EdYQpMYdVkCfq08KDh2pmlVqK5t5IA9mGs4/LwCwp4fqisSOMXZxP3HIh8w8aRn0A==",
       "dependencies": {
         "mitt": "3.0.1",
-        "urlpattern-polyfill": "10.0.0"
+        "urlpattern-polyfill": "10.0.0",
+        "zod": "3.23.8"
       },
       "peerDependencies": {
         "devtools-protocol": "*"
@@ -1953,9 +1963,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2022,14 +2032,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/cross-fetch": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-      "dependencies": {
-        "node-fetch": "^2.6.12"
       }
     },
     "node_modules/cross-spawn": {
@@ -2159,9 +2161,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1249869",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1249869.tgz",
-      "integrity": "sha512-Ctp4hInA0BEavlUoRy9mhGq0i+JSo/AwVyX2EFgZmV1kYB+Zq+EMBAn52QWu6FbRr10hRb6pBl420upbp4++vg=="
+      "version": "0.0.1312386",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
+      "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA=="
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -2451,16 +2453,16 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -2491,41 +2493,18 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/express/node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.1",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
+    "node_modules/express-rate-limit": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.4.0.tgz",
+      "integrity": "sha512-v1204w3cXu5gCDmAvgvzI6qjzZzoMWKnyVDk3ACgfswTQLYiGen+r8w0VnXnGMmzEN/g8fwIQ4JrFFd4ZP6ssg==",
       "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/express/node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "node": ">= 16"
       },
-      "engines": {
-        "node": ">= 0.8"
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "4 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/extract-zip": {
@@ -2548,9 +2527,9 @@
       }
     },
     "node_modules/extract-zip/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2617,9 +2596,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -2659,9 +2638,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -2826,9 +2805,9 @@
       }
     },
     "node_modules/get-uri/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2982,9 +2961,9 @@
       }
     },
     "node_modules/http-proxy-agent/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -3003,9 +2982,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -3015,9 +2994,9 @@
       }
     },
     "node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -3140,10 +3119,22 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "node_modules/ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -3920,6 +3911,11 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -4048,14 +4044,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -4326,44 +4319,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4510,27 +4465,27 @@
       }
     },
     "node_modules/pac-proxy-agent": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
-      "integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==",
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
         "get-uri": "^6.0.1",
         "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
-        "pac-resolver": "^7.0.0",
-        "socks-proxy-agent": "^8.0.2"
+        "https-proxy-agent": "^7.0.5",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.4"
       },
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/pac-proxy-agent/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -4779,9 +4734,9 @@
       }
     },
     "node_modules/proxy-agent/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -4792,14 +4747,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/proxy-agent/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/proxy-agent/node_modules/ms": {
@@ -4830,14 +4777,15 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.3.0.tgz",
-      "integrity": "sha512-GC+tyjzYKjaNjhlDAuqRgDM+IOsqOG75Da4L28G4eULNLLxKDt+79x2OOSQ47HheJBgGq7ATSExNE6gayxP6cg==",
+      "version": "22.15.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.15.0.tgz",
+      "integrity": "sha512-XjCY1SiSEi1T7iSYuxS82ft85kwDJUS7wj1Z0eGVXKdtr5g4xnVcbjwxhq5xBnpK/E7x1VZZoJDxpjAOasHT4Q==",
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "2.1.0",
-        "cosmiconfig": "9.0.0",
-        "puppeteer-core": "22.3.0"
+        "@puppeteer/browsers": "2.3.0",
+        "cosmiconfig": "^9.0.0",
+        "devtools-protocol": "0.0.1312386",
+        "puppeteer-core": "22.15.0"
       },
       "bin": {
         "puppeteer": "lib/esm/puppeteer/node/cli.js"
@@ -4847,25 +4795,24 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.3.0.tgz",
-      "integrity": "sha512-Ho5Vdpdro05ZyCx/l5Hkc5vHiibKTaY37fIAD9NF9Gi/vDxkVTeX40U/mFnEmeoxyuYALvWCJfi7JTT82R6Tuw==",
+      "version": "22.15.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.15.0.tgz",
+      "integrity": "sha512-cHArnywCiAAVXa3t4GGL2vttNxh7GqXtIYGym99egkNJ3oG//wL9LkvO4WE8W1TJe95t1F1ocu9X4xWaGsOKOA==",
       "dependencies": {
-        "@puppeteer/browsers": "2.1.0",
-        "chromium-bidi": "0.5.10",
-        "cross-fetch": "4.0.0",
-        "debug": "4.3.4",
-        "devtools-protocol": "0.0.1249869",
-        "ws": "8.16.0"
+        "@puppeteer/browsers": "2.3.0",
+        "chromium-bidi": "0.6.3",
+        "debug": "^4.3.6",
+        "devtools-protocol": "0.0.1312386",
+        "ws": "^8.18.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/puppeteer-core/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -5026,12 +4973,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5156,35 +5100,35 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },
     "node_modules/socks-proxy-agent": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.2.tgz",
-      "integrity": "sha512-8zuqoLv1aP/66PHF5TqwJ7Czm3Yv32urJQHrVyhD7mmA6d61Zv8cIXQYPTWwmg6qlupnPvs/QKDmfa4P/qct2g==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
+      "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.1",
         "debug": "^4.3.4",
-        "socks": "^2.7.1"
+        "socks": "^2.8.3"
       },
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/socks-proxy-agent/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -5257,12 +5201,13 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.16.1.tgz",
-      "integrity": "sha512-m9QYj6WygWyWa3H1YY69amr4nVgy61xfjys7xO7kviL5rfIEc2naf+ewFiOA+aEJD7y0JO3h2GoiUv4TDwEGzQ==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.18.0.tgz",
+      "integrity": "sha512-LLUC1TWdjVdn1weXGcSxyTR3T4+acB6tVGXT95y0nGbca4t4o/ng1wKAGTljm9VicuCVLvRlqFYXYy5GwgM7sQ==",
       "dependencies": {
-        "fast-fifo": "^1.1.0",
-        "queue-tick": "^1.0.1"
+        "fast-fifo": "^1.3.2",
+        "queue-tick": "^1.0.1",
+        "text-decoder": "^1.1.0"
       },
       "optionalDependencies": {
         "bare-events": "^2.2.0"
@@ -5428,9 +5373,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
-      "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
+      "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
       "dependencies": {
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
@@ -5462,6 +5407,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.1.tgz",
+      "integrity": "sha512-8zll7REEv4GDD3x4/0pW+ppIxSNs7H1J10IKFZsuOMscumCdM2a+toDGLPA3T+1+fLBql4zbt5z83GEQGGV5VA==",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/through": {
@@ -5516,9 +5469,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -5728,9 +5681,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -5754,11 +5707,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -5804,6 +5752,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.6.7",
         "body-parser": "^1.20.2",
         "cheerio": "^1.0.0-rc.12",
+        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
@@ -1966,6 +1967,26 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }

--- a/api/package.json
+++ b/api/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.6.7",
     "body-parser": "^1.20.2",
     "cheerio": "^1.0.0-rc.12",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",

--- a/api/package.json
+++ b/api/package.json
@@ -17,6 +17,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "express-rate-limit": "^7.4.0",
     "iso8601-duration": "^2.1.2",
     "jsonwebtoken": "^9.0.1",
     "mongoose": "^7.4.1",

--- a/api/routes/authentication.js
+++ b/api/routes/authentication.js
@@ -5,6 +5,10 @@ const AuthenticationController = require("../controllers/authentication");
 const tokenChecker = require("../middleware/tokenChecker");
 
 router.post("/", AuthenticationController.createToken);
+router.get("/refresh", AuthenticationController.refreshToken); 
+router.post("/logout", AuthenticationController.logout); 
+
+//TODO:I THINK UNECESSARY. Only used by RecipeScraper on frontend. But the route is already checked by a token checker!
 router.get("/", tokenChecker, AuthenticationController.checkToken);
 
 module.exports = router;

--- a/api/routes/authentication.js
+++ b/api/routes/authentication.js
@@ -5,7 +5,7 @@ const AuthenticationController = require("../controllers/authentication");
 const tokenChecker = require("../middleware/tokenChecker");
 
 router.post("/", loginLimiter, AuthenticationController.createToken);
-router.get("/refresh", AuthenticationController.refreshToken); 
+router.get("/refresh", AuthenticationController.refresh); 
 router.post("/logout", AuthenticationController.logOut); 
 
 //TODO:I THINK UNECESSARY. Only used by RecipeScraper on frontend. But the route is already checked by a token checker!

--- a/api/routes/authentication.js
+++ b/api/routes/authentication.js
@@ -5,7 +5,7 @@ const AuthenticationController = require("../controllers/authentication");
 const tokenChecker = require("../middleware/tokenChecker");
 
 router.post("/", loginLimiter, AuthenticationController.createToken);
-router.get("/refresh", AuthenticationController.refresh); 
+router.post("/refresh", AuthenticationController.refresh); 
 router.post("/logout", AuthenticationController.logOut); 
 
 //TODO:I THINK UNECESSARY. Only used by RecipeScraper on frontend. But the route is already checked by a token checker!

--- a/api/routes/authentication.js
+++ b/api/routes/authentication.js
@@ -1,12 +1,12 @@
 const express = require("express");
 const router = express.Router();
-
+const loginLimiter = require("../middleware/loginLimiter")
 const AuthenticationController = require("../controllers/authentication");
 const tokenChecker = require("../middleware/tokenChecker");
 
-router.post("/", AuthenticationController.createToken);
+router.post("/", loginLimiter, AuthenticationController.createToken);
 router.get("/refresh", AuthenticationController.refreshToken); 
-router.post("/logout", AuthenticationController.logout); 
+router.post("/logout", AuthenticationController.logOut); 
 
 //TODO:I THINK UNECESSARY. Only used by RecipeScraper on frontend. But the route is already checked by a token checker!
 router.get("/", tokenChecker, AuthenticationController.checkToken);

--- a/api/tests/controllers/authentication.test.js
+++ b/api/tests/controllers/authentication.test.js
@@ -11,11 +11,7 @@ describe("/tokens", () => {
       username: "someone",
     });
 
-    // We need to use `await` so that the "beforeAll" setup function waits for
-    // the asynchronous user.save() to be done before exiting.
-    // Otherwise, the tests belowc ould run without the user actyakkt being
-    // saved, causing tests to fail inconsistently.
-    await user.save();
+   await user.save();
   });
 
   afterAll(async () => {
@@ -30,7 +26,7 @@ describe("/tokens", () => {
 
     expect(response.status).toEqual(201);
     expect(response.body.token).not.toEqual(undefined);
-    expect(response.body.message).toEqual("OK");
+    expect(response.body.message).toEqual("Login successful.");
   });
 
   test("doesn't return a token when the user doesn't exist", async () => {
@@ -41,7 +37,7 @@ describe("/tokens", () => {
 
     expect(response.status).toEqual(401);
     expect(response.body.token).toEqual(undefined);
-    expect(response.body.message).toEqual("User not found");
+    expect(response.body.message).toEqual("Please check your login details.");
   });
 
   test("doesn't return a token when the wrong password is given", async () => {
@@ -52,6 +48,6 @@ describe("/tokens", () => {
 
     expect(response.status).toEqual(401);
     expect(response.body.token).toEqual(undefined);
-    expect(response.body.message).toEqual("Password incorrect");
+    expect(response.body.message).toEqual("Please check your login details.");
   });
 });

--- a/api/tests/controllers/authentication.test.js
+++ b/api/tests/controllers/authentication.test.js
@@ -2,6 +2,8 @@ const app = require("../../app");
 const supertest = require("supertest");
 require("../mongodb_helper");
 const User = require("../../models/user");
+const JWT = require('jsonwebtoken');
+const { decodeToken } = require("../../lib/token");
 
 describe("/tokens", () => {
   beforeAll(async () => {
@@ -11,43 +13,131 @@ describe("/tokens", () => {
       username: "someone",
     });
 
-   await user.save();
+    await user.save();
   });
 
   afterAll(async () => {
     await User.deleteMany({});
   });
+  describe("createToken method:", () => {
+    test("returns a token when credentials are valid", async () => {
+      const testApp = supertest(app);
+      const response = await testApp.post("/tokens").send({
+        email: "auth-test@test.com",
+        password: "12345678",
+        username: "someone",
+      });
 
-  test("returns a token when credentials are valid", async () => {
-    const testApp = supertest(app);
-    const response = await testApp
-      .post("/tokens")
-      .send({ email: "auth-test@test.com", password: "12345678", username: "someone" });
+      expect(response.status).toEqual(201);
+      expect(response.body.token).not.toEqual(undefined);
+      expect(response.body.message).toEqual("Login successful.");
+    });
 
-    expect(response.status).toEqual(201);
-    expect(response.body.token).not.toEqual(undefined);
-    expect(response.body.message).toEqual("Login successful.");
+    test("doesn't return a token when the user doesn't exist", async () => {
+      const testApp = supertest(app);
+      const response = await testApp.post("/tokens").send({
+        email: "non-existent@test.com",
+        password: "1234",
+        username: "someone",
+      });
+
+      expect(response.status).toEqual(401);
+      expect(response.body.token).toEqual(undefined);
+      expect(response.body.message).toEqual("Please check your login details.");
+    });
+
+    test("doesn't return a token when the wrong password is given", async () => {
+      const testApp = supertest(app);
+      const response = await testApp.post("/tokens").send({
+        email: "auth-test@test.com",
+        password: "1234",
+        username: "someone",
+      });
+
+      expect(response.status).toEqual(401);
+      expect(response.body.token).toEqual(undefined);
+      expect(response.body.message).toEqual("Please check your login details.");
+    });
   });
 
-  test("doesn't return a token when the user doesn't exist", async () => {
+  describe("refresh method:", () => {
+    test("returns a token when 'refresh' token is valid", async () => {
+      const testApp = supertest(app);
+      const loginResponse = await testApp.post("/tokens").send({
+        email: "auth-test@test.com",
+        password: "12345678",
+        username: "someone",
+      });
+
+      const cookies = loginResponse.headers["set-cookie"];
+
+      const response = await testApp
+        .post("/tokens/refresh")
+        .set("Cookie", cookies)
+        .send();
+
+      expect(response.status).toEqual(201);
+      expect(response.body.token).not.toEqual(undefined);
+      expect(response.body.message).toEqual("Access token issued.");
+    });
+  });
+  
+  test("returns 401 when a cookie doesn't exist", async () => {
     const testApp = supertest(app);
+    // const loginResponse = await testApp.post("/tokens").send({
+    //   email: "auth-test@test.com",
+    //   password: "12345678",
+    //   username: "someone",
+    // });
+
     const response = await testApp
-      .post("/tokens")
-      .send({ email: "non-existent@test.com", password: "1234", username: "someone" });
+    .post("/tokens/refresh")
+    .send();
 
     expect(response.status).toEqual(401);
     expect(response.body.token).toEqual(undefined);
-    expect(response.body.message).toEqual("Please check your login details.");
+    expect(response.body.message).toEqual("Unauthorized");
   });
 
-  test("doesn't return a token when the wrong password is given", async () => {
-    let testApp = supertest(app);
+  test("returns 403 for expired 'refresh' token", async () => {
+    const expiredToken = JWT.sign({ user_id: "validUserId" }, process.env.REFRESH_TOKEN_SECRET, { expiresIn: '0s' }); 
+    const testApp = supertest(app);
+
     const response = await testApp
-      .post("/tokens")
-      .send({ email: "auth-test@test.com", password: "1234", username: "someone" });
+    .post("/tokens/refresh")
+    .set("Cookie", `jwt=${expiredToken}`)
+    .send();
+
+    expect(response.status).toEqual(403);
+    expect(response.body.token).toEqual(undefined);
+    expect(response.body.message).toEqual("Forbidden");
+  }); 
+
+  test("returns 403 for invalid 'refresh' token", async () => {
+    const invalidtoken = "invalid.token"
+    const testApp = supertest(app);
+
+    const response = await testApp
+    .post("/tokens/refresh")
+    .set("Cookie", `jwt=${invalidtoken}`)
+    .send();
+
+    expect(response.status).toEqual(403);
+    expect(response.body.token).toEqual(undefined);
+    expect(response.body.message).toEqual("Forbidden");
+  })
+
+  test("returns 401 for non-existant user", async () => {
+    const nonUserToken = JWT.sign({ user_id: "nonUserId" }, process.env.REFRESH_TOKEN_SECRET); 
+    const testApp = supertest(app);
+
+    const response = await testApp
+    .post("/tokens/refresh")
+    .set("Cookie", `jwt=${nonUserToken}`)
+    .send();
 
     expect(response.status).toEqual(401);
     expect(response.body.token).toEqual(undefined);
-    expect(response.body.message).toEqual("Please check your login details.");
-  });
+    expect(response.body.message).toEqual("Unauthorized");
+  })
 });

--- a/api/tests/controllers/users.test.js
+++ b/api/tests/controllers/users.test.js
@@ -9,7 +9,11 @@ describe("/users", () => {
   beforeEach(async () => {
     await User.deleteMany({});
   });
-
+  
+  afterAll(async() => {
+    await User.deleteMany({}); 
+  })
+  
   describe("POST, when email, password and username are provided", () => {
     test("the response code is 201", async () => {
       const response = await request(app)

--- a/api/tests/lib/token.test.js
+++ b/api/tests/lib/token.test.js
@@ -1,8 +1,12 @@
-const { generateToken, decodeToken } = require("../../lib/token");
+const {
+  generateToken,
+  generateRefreshToken,
+  decodeToken,
+} = require("../../lib/token");
 
 describe("TokenGenerator", () => {
-  describe("jsonwebtoken", () => {
-    test("returns a token containing user_id that is valid for 10 minutes", () => {
+  describe("generateToken:", () => {
+    test("returns an 'access' token containing user_id that is valid for 10 minutes", () => {
       const id_1 = 1;
       const id_2 = 2;
 
@@ -20,6 +24,26 @@ describe("TokenGenerator", () => {
 
       // Token is valid for 600 seconds (10 minutes)
       expect(payload_1.exp - payload_1.iat).toEqual(600);
+    });
+  });
+
+  describe("generateRefreshTokeh:", () => {
+    test("returns a 'refresh' token containing user_id that is valid for 1 day", () => {
+      const id_1 = 1;
+      const id_2 = 2;
+
+      const token_1 = generateRefreshToken(id_1);
+      const token_2 = generateRefreshToken(id_2);
+      expect(token_1).not.toEqual(token_2);
+
+      const payload_1 = decodeToken(token_1);
+      const payload_2 = decodeToken(token_2);
+
+      expect(payload_1.user_id).toEqual(id_1);
+      expect(payload_2.user_id).toEqual(id_2);
+
+      // Token is valid for 1 day
+      expect(payload_1.exp - payload_1.iat).toEqual(86400);
     });
   });
 });

--- a/api/tests/models/user.test.js
+++ b/api/tests/models/user.test.js
@@ -6,6 +6,10 @@ describe("User model", () => {
     await User.deleteMany({});
   });
 
+  afterAll(async() => {
+    await User.deleteMany({}); 
+  })
+  
   it("has an email address", () => {
     const user = new User({
       email: "someone@example.com",

--- a/frontend/src/components/RecipeScraper.jsx
+++ b/frontend/src/components/RecipeScraper.jsx
@@ -15,7 +15,9 @@ const RecipeScraper = ({
   const handleClick = async (manual) => {
     try {
       // Changed to props.token instead of window.localStorage.getItem()
+      // TODO: UNECESSARY
       await checkToken(token);
+      //
       if (!manual) {
         await handleScrapeRecipe();
       } else {


### PR DESCRIPTION
## Description: 

The way JWT authorisation was handled previously was inadequate. We previously understood the users controller to be in charge of logging in / out but actually it should probably be handled by the authorisation controller. 

I've added new routes:
- refresh token
- log out

Previously, a new JWT was issued upon every request. Instead, two JWT tokens will be issued. One will be the 'access' token that will work like the current implementation and a new "refresh" token. 

The refresh token is a longer-lived authorisation token. 
The refresh token will be stored as a HTTP-only cookie which will be more secure as it won't accessible by JavaScript by attackers.

When an access token expires  (e.g. in 10 minutes), the refresh token will be used to get a new 'access' token. 

As a result, an 'access' token will not need to be issued upon every request like previously, reducing issuance resource overhead. It'll also be more secure as the 'refresh' token mitigates against some attacks. 