### PR TITLE
32 update single recipe page

### DIFF
--- a/api/controllers/authentication.js
+++ b/api/controllers/authentication.js
@@ -40,7 +40,7 @@ const createToken = async (req, res) => {
       maxAge: 7 * 24 * 60 * 60 * 1000,
     });
 
-    res.status(201).json({ token: accessToken, message: "Login successful." });
+    return res.status(201).json({ token: accessToken, message: "Login successful." });
   } catch (err) {
     return res.status(500).json({ message: "Internal server error." });
   }
@@ -59,7 +59,7 @@ const refresh = async (req, res) => {
     const user = await User.findById(payload.user_id).exec();
 
     const accessToken = generateToken(user.id);
-    res
+    return res
       .status(201)
       .json({ token: accessToken, message: "Access token issued." });
   } catch (err) {

--- a/api/controllers/recipes.js
+++ b/api/controllers/recipes.js
@@ -9,7 +9,7 @@ const { extractRecipeInfo } = require("../utils/recipeUtils");
 const index = async (req, res) => {
   try {
     const recipes = await Recipe.find({ ownerId: req.user_id });
-    res.status(200).json({ recipes: recipes });
+    res.status(200).json({ data : recipes });
   } catch (error) {
     res.status(500).json({ error: error.message });
   }
@@ -26,7 +26,7 @@ const show = async (req, res) => {
   //Question: Do we need to return user id?
   res
     .status(200)
-    .json({ recipeData: recipeData, user_id: req.user_id, token: newToken });
+    .json({ data : recipeData, user_id: req.user_id, token: newToken });
 };
 
 const create = async (req, res) => {
@@ -92,25 +92,17 @@ const update = async (req, res) => {
       image: req.body.image,
       dateAdded: req.body.dateAdded,
     };
-
+    console.log(recipeUpdateData);
     const updatedRecipe = await Recipe.findOneAndUpdate(
       { _id: recipeId, ownerId: user._id },
       { $set: recipeUpdateData },
       { new: true }
     );
-
     if (!updatedRecipe) {
       return res.status(404).json({ message: "Recipe not found" });
     }
-    const newToken = generateToken(req.user_id);
     res.status(200).json({
       message: "Recipe updated successfully",
-
-      //TODO:
-      //Question: Do we need to return the updatedRecipe if the data isn't being used?
-      //The SingleRecipePage uses a useEffect to create another Fetch request to get recipe data
-      updatedRecipe,
-      token: newToken,
     });
   } catch (error) {
     console.error(error);

--- a/api/controllers/recipes.js
+++ b/api/controllers/recipes.js
@@ -92,7 +92,7 @@ const update = async (req, res) => {
       image: req.body.image,
       dateAdded: req.body.dateAdded,
     };
-    console.log(recipeUpdateData);
+
     const updatedRecipe = await Recipe.findOneAndUpdate(
       { _id: recipeId, ownerId: user._id },
       { $set: recipeUpdateData },

--- a/api/controllers/users.js
+++ b/api/controllers/users.js
@@ -41,41 +41,9 @@ const create = async (req, res) => {
   }
 };
 
-//TODO: Implement
-//This controller isn't actually being used and can't be used until the create function above hashes password
-const login = async (req, res) => {
-  const { email, password } = req.body;
-
-  try {
-    const user = await User.findOne({ email });
-    if (!user) {
-      return res.status(404).json({ message: "User not found" });
-    }
-
-    const passwordMatch = await bcrypt.compare(password, user.password);
-    if (!passwordMatch) {
-      return res.status(401).json({ message: "Invalid email or password" });
-    }
-
-    const token = generateToken(user._id);
-
-    res.status(200).json({ token });
-  } catch (error) {
-    console.error(error);
-    res.status(500).json({ message: "Internal server error" });
-  }
-};
-
-//TODO: CAN DELETE as JWT implementation has changed
-const logout = (req, res) => {
-  res.status(200).json({ message: "Logout successful" });
-};
 
 const UsersController = {
   create: create,
-  login: login,
-  logout,
-  logout,
 };
 
 module.exports = UsersController;

--- a/api/tests/controllers/recipes.test.js
+++ b/api/tests/controllers/recipes.test.js
@@ -22,7 +22,7 @@ const createToken = (userId) => {
   );
 };
 
-let token;
+// let token;
 let decodedToken;
 describe("/recipes", () => {
   beforeAll(async () => {
@@ -160,7 +160,7 @@ describe("/recipes/:recipe_id", () => {
         .get(`/recipes/${recipe._id}`)
         .set("Authorization", `Bearer ${token}`);
 
-      const recipeData = response.body.recipeData;
+      const recipeData = response.body.data;
 
       expect(recipeData.name).toEqual("Easy blueberry muffins");
       expect(recipeData.description).toEqual(
@@ -195,19 +195,6 @@ describe("/recipes/:recipe_id", () => {
         "https://images.immediate.co.uk/production/volatile/sites/30/2020/08/blueberry-muffin-ee95fd4.jpg?resize=768,574"
       );
       expect(recipeData.dateAdded).toEqual("2024-03-04T00:00:00.000Z");
-    });
-
-    test("returns a new token", async () => {
-      const response = await request(app)
-        .get(`/recipes/${recipe._id}`)
-        .set("Authorization", `Bearer ${token}`);
-
-      const newToken = response.body.token;
-      const newTokenDecoded = JWT.decode(newToken, process.env.JWT_SECRET);
-      const oldTokenDecoded = JWT.decode(token, process.env.JWT_SECRET);
-
-      // iat stands for issued at
-      expect(newTokenDecoded.iat > oldTokenDecoded.iat).toEqual(true);
     });
   });
 
@@ -289,19 +276,19 @@ describe("Get Recipes tests", () => {
   });
 
   describe("GET - all recipes - when token is present", () => {
-    test("response code is 200, returns a new token, recipes match userID and returned recipes are correct", async () => {
+    test("response code is 200, recipes match userID and returned recipes are correct", async () => {
       const response = await request(app)
-        .get(`/recipes/`)
+        .get(`/recipes`)
         .set("Authorization", `Bearer ${token}`);
 
       const responseBody = response.body;
 
       expect(response.status).toEqual(200);
       // Returned data is correct
-      expect(responseBody).toHaveProperty("recipes");
-      expect(responseBody.recipes.length).toBe(2);
+      expect(responseBody).toHaveProperty("data");
+      expect(responseBody.data.length).toBe(2);
 
-      expect(responseBody.recipes[0]).toEqual(
+      expect(responseBody.data[0]).toEqual(
         // In the test, we are comparing JSON data to a MongoDB object
         // Problem - comparing a date object, MongoDB's ObjectID to strings
         // .toObject is a Mongoose method and it can take the "transform" function.
@@ -318,7 +305,7 @@ describe("Get Recipes tests", () => {
           },
         })
       );
-      expect(responseBody.recipes[1]).toEqual(
+      expect(responseBody.data[1]).toEqual(
         recipe2.toObject({
           transform: (doc, ret) => {
             ret.dateAdded = ret.dateAdded.toISOString();
@@ -336,11 +323,11 @@ describe("Get Recipes tests", () => {
       const responseBody = response.body;
 
       //Returned recipes are only for user1(ownerId)
-      expect(responseBody.recipes[0].ownerId).toEqual(ownerId.toString());
-      expect(responseBody.recipes[1].ownerId).toEqual(ownerId.toString());
-      //Returned recipes don't belong to user2(ownerId2)
-      expect(responseBody.recipes[0].ownerId).not.toEqual(ownerId2.toString());
-      expect(responseBody.recipes[1].ownerId).not.toEqual(ownerId2.toString());
+      expect(responseBody.data[0].ownerId).toEqual(ownerId.toString());
+      expect(responseBody.data[1].ownerId).toEqual(ownerId.toString());
+      //Returned data don't belong to user2(ownerId2)
+      expect(responseBody.data[0].ownerId).not.toEqual(ownerId2.toString());
+      expect(responseBody.data[1].ownerId).not.toEqual(ownerId2.toString());
     });
   });
 

--- a/frontend/src/components/Recipe/RecipeCard.jsx
+++ b/frontend/src/components/Recipe/RecipeCard.jsx
@@ -21,7 +21,7 @@ const RecipeCard = ({ recipe }) => {
             </figcaption>
           </figure>
         </Link>
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between w-full mt-4">
           <div className="flex items-center font-kanit font-bold gap-0.5 text-secondary-500">
             <img
               className="size-8 mr-2"

--- a/frontend/src/hooks/useFetchRecipe.js
+++ b/frontend/src/hooks/useFetchRecipe.js
@@ -4,7 +4,7 @@ import useAxiosPrivate from "./useAxiosPrivate";
 export const useFetchRecipes = () => {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
+  const [error, setError] = useState({});
   const axiosPrivate = useAxiosPrivate();
 
   const fetchRecipes = useCallback(

--- a/frontend/src/hooks/useFetchRecipe.js
+++ b/frontend/src/hooks/useFetchRecipe.js
@@ -2,39 +2,42 @@ import { useState, useCallback } from "react";
 import useAxiosPrivate from "./useAxiosPrivate";
 
 export const useFetchRecipes = () => {
-  const [recipes, setRecipes] = useState([]);
+  const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const axiosPrivate = useAxiosPrivate();
 
-  const fetchRecipes = useCallback(async (path) => {
-    try {
-      const response = await axiosPrivate.get(path);
-      setRecipes(response.data.recipes);
-      setLoading(false);
-    } catch (err) {
-      setLoading(false);
-      if (!err?.response) {
+  const fetchRecipes = useCallback(
+    async (path) => {
+      try {
+        const response = await axiosPrivate.get(path);
+        setData(response.data.data);
+        setLoading(false);
+      } catch (err) {
+        setLoading(false);
+        if (!err?.response) {
+          setError({
+            type: "no-server-response",
+            message:
+              "No Server Response. Please check your internet connection or try again later.",
+          });
+          return;
+        }
+        if (err?.response.status === 401 || err?.response.status === 403) {
+          setError({
+            type: "auth-error",
+            message: "Unauthorized access. Please log in again.",
+          });
+          return;
+        }
         setError({
-          type: "no-server-response",
-          message:
-            "No Server Response. Please check your internet connection or try again later.",
+          type: "unexpected-error",
+          message: "An unexpected error occurred.",
         });
-        return;
       }
-      if (err?.response.status === 401 || err?.response.status === 403) {
-        setError({
-          type: "auth-error",
-          message: "Unauthorized access. Please log in again.",
-        });
-        return;
-      }
-      setError({
-        type: "unexpected-error",
-        message: "An unexpected error occurred.",
-      });
-    }
-  }, []);
+    },
+    [axiosPrivate],
+  );
 
-  return { recipes, loading, error, fetchRecipes };
+  return { data, loading, error, fetchRecipes };
 };

--- a/frontend/src/hooks/useFetchRecipe.js
+++ b/frontend/src/hooks/useFetchRecipe.js
@@ -7,19 +7,34 @@ export const useFetchRecipes = () => {
   const [error, setError] = useState(false);
   const axiosPrivate = useAxiosPrivate();
 
-  const fetchRecipes = useCallback(async () => {
+  const fetchRecipes = useCallback(async (path) => {
     try {
-      const response = await axiosPrivate.get("/recipes");
+      const response = await axiosPrivate.get(path);
       setRecipes(response.data.recipes);
       setLoading(false);
     } catch (err) {
-      if (!err?.response) {
-        setError("No Server Response");
-      }
       setLoading(false);
-      setError(true);
+      if (!err?.response) {
+        setError({
+          type: "no-server-response",
+          message:
+            "No Server Response. Please check your internet connection or try again later.",
+        });
+        return;
+      }
+      if (err?.response.status === 401 || err?.response.status === 403) {
+        setError({
+          type: "auth-error",
+          message: "Unauthorized access. Please log in again.",
+        });
+        return;
+      }
+      setError({
+        type: "unexpected-error",
+        message: "An unexpected error occurred.",
+      });
     }
-  }, [axiosPrivate]);
+  }, []);
 
   return { recipes, loading, error, fetchRecipes };
 };

--- a/frontend/src/pages/MyRecipes/MyRecipesPage.jsx
+++ b/frontend/src/pages/MyRecipes/MyRecipesPage.jsx
@@ -15,21 +15,33 @@ export const MyRecipesPage = ({
   const { recipes, loading, error, fetchRecipes } = useFetchRecipes();
 
   useEffect(() => {
-    fetchRecipes();
+    fetchRecipes("/recipes");
   }, [fetchRecipes]);
+
+  useEffect(() => {
+    if (error.type === "auth-error") {
+      console.log(error.message);
+      navigate("/login");
+    }
+  }, [error, navigate]);
 
   const renderPageContent = () => {
     if (loading) {
       return <p aria-label="Loading message">Loading ...</p>;
     }
 
-    if (error) {
-      console.log("Error occured whilst retrieving recipe");
-      // return <p>Error: {error.message}</p>;
-      navigate("/login");
+    if (
+      error.type === "no-server-response" ||
+      error.type === "unexpected-error"
+    ) {
+      return <p aria-label="error message">{`${error.message}`}</p>;
     }
 
-    if ((!loading && !error && recipes === undefined) || recipes.length === 0) {
+    if (
+      !loading &&
+      Object.keys(error).length === 0 &&
+      (!recipes || recipes.length === 0)
+    ) {
       return <p aria-label="Empty Recipes"> Start saving recipes!</p>;
     }
 

--- a/frontend/src/pages/MyRecipes/MyRecipesPage.jsx
+++ b/frontend/src/pages/MyRecipes/MyRecipesPage.jsx
@@ -12,7 +12,7 @@ export const MyRecipesPage = ({
   setRecipeData,
 }) => {
   const navigate = useNavigate();
-  const { recipes, loading, error, fetchRecipes } = useFetchRecipes();
+  const { data, loading, error, fetchRecipes } = useFetchRecipes();
 
   useEffect(() => {
     fetchRecipes("/recipes");
@@ -40,12 +40,12 @@ export const MyRecipesPage = ({
     if (
       !loading &&
       Object.keys(error).length === 0 &&
-      (!recipes || recipes.length === 0)
+      (!data || data.length === 0)
     ) {
       return <p aria-label="Empty Recipes"> Start saving recipes!</p>;
     }
 
-    return recipes.map((recipe, index) => {
+    return data.map((recipe, index) => {
       return <RecipeCard recipe={recipe} key={index} />;
     });
   };

--- a/frontend/src/pages/MyRecipes/MyRecipesPage.jsx
+++ b/frontend/src/pages/MyRecipes/MyRecipesPage.jsx
@@ -20,7 +20,7 @@ export const MyRecipesPage = ({
 
   useEffect(() => {
     if (error.type === "auth-error") {
-      console.log(error.message);
+      // console.log(error.message);
       navigate("/login");
     }
   }, [error, navigate]);

--- a/frontend/src/pages/RecipePage/SingleRecipePage.jsx
+++ b/frontend/src/pages/RecipePage/SingleRecipePage.jsx
@@ -95,6 +95,9 @@ export const SingleRecipePage = () => {
     } catch (err) {
       //TODO: Need to figureout appropriate error modal
       console.log(err);
+      if (err?.response.status === 401) {
+        navigate("/login");
+      }
     }
   };
 

--- a/frontend/src/pages/RecipePage/SingleRecipePage.jsx
+++ b/frontend/src/pages/RecipePage/SingleRecipePage.jsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
-import { updateRecipe, getRecipeById } from "../../services/recipes";
+import { useFetchRecipes } from "../../hooks/useFetchRecipe";
+import useAxiosPrivate from "../../hooks/useAxiosPrivate";
 
 import { Tags } from "../../components/RecipePage/RecipeFields/Tags";
 import { IngredientList } from "../../components/RecipePage/RecipeFields/IngredientList";
@@ -17,13 +18,14 @@ import { SaveButton } from "../../components/RecipePage/SaveButton";
 import { EditButton } from "../../components/RecipePage/EditButton";
 import { FavouriteButton } from "../../components/RecipePage/FavouriteButton";
 
-export const SingleRecipePage = ({ token, setToken }) => {
+export const SingleRecipePage = () => {
   const navigate = useNavigate();
+  const axiosPrivate = useAxiosPrivate();
+  const { data, loading, error, fetchRecipes } = useFetchRecipes();
 
   const { recipe_id } = useParams();
 
   const [editMode, setEditMode] = useState(false);
-
   const [recipeName, setRecipeName] = useState("");
   const [recipeDescription, setRecipeDescription] = useState("");
   const [yieldAmount, setYieldAmount] = useState(0);
@@ -35,30 +37,31 @@ export const SingleRecipePage = ({ token, setToken }) => {
   const [recipeUrl, setRecipeUrl] = useState("");
 
   useEffect(() => {
-    if (token) {
-      getRecipeById(recipe_id, token)
-        .then((data) => {
-          setRecipeName(data.recipeData.name);
-          setRecipeDescription(data.recipeData.description);
-          setYieldAmount(data.recipeData.recipeYield);
-          setRecipeTotalTime(data.recipeData.totalTime);
-          setIngredients(data.recipeData.recipeIngredient);
-          setInstructions(data.recipeData.recipeInstructions);
-          setImageUrl(data.recipeData.image);
-          setRecipeUrl(data.recipeData.url);
-          setRecipeTags(data.recipeData.tags);
-
-          setToken(data.token);
-          //TODO: Do we need this line if setToken above has state set?
-          window.localStorage.setItem("token", data.token);
-        })
-        .catch((err) => {
-          console.error(err);
-        });
+    if (recipe_id) {
+      fetchRecipes(`/recipes/${recipe_id}`);
     } else {
-      navigate("/");
+      navigate("/myrecipes");
     }
-  }, [token]);
+  }, [fetchRecipes, navigate, recipe_id]);
+
+  useEffect(() => {
+    if (error.type === "auth-error") {
+      console.log(error.message);
+      navigate("/login");
+    }
+
+    if (data) {
+      setRecipeName(data.name || "");
+      setRecipeDescription(data.description || "");
+      setYieldAmount(data.recipeYield || 0);
+      setRecipeTotalTime(data.totalTime || 0);
+      setIngredients(data.recipeIngredient || []);
+      setInstructions(data.recipeInstructions || []);
+      setImageUrl(data.image || "");
+      setRecipeUrl(data.url || "");
+      setRecipeTags(data.tags || []);
+    }
+  }, [data, error, navigate]);
 
   const handleSaveRecipe = async () => {
     if (
@@ -68,95 +71,129 @@ export const SingleRecipePage = ({ token, setToken }) => {
       ingredients.some((ingredient) => ingredient === "") ||
       instructions.some((instruction) => instruction === "")
     ) {
+      //TODO:This should really be some Modal.
       alert("Please fill out all the required fields");
-    } else {
-      let data = await updateRecipe(
-        token,
-        recipe_id,
-        recipeName,
-        recipeDescription,
-        recipeTags,
-        recipeTotalTime,
-        yieldAmount,
-        ingredients,
-        instructions,
-        recipeUrl,
-        imageUrl
-      );
-      setToken(data.token);
+      return;
+    }
+
+    try {
+      const data = {
+        name: recipeName,
+        description: recipeDescription,
+        tags: recipeTags,
+        totalTime: recipeTotalTime,
+        recipeYield: yieldAmount,
+        recipeIngredient: ingredients,
+        recipeInstructions: instructions,
+        url: recipeUrl,
+        image: imageUrl,
+        dateAdded: new Date().toISOString(),
+      };
+
+      await axiosPrivate.patch(`/recipes/${recipe_id}`, data);
       setEditMode(!editMode);
+    } catch (err) {
+      //TODO: Need to figureout appropriate error modal
+      console.log(err);
     }
   };
 
-  return (
-    <div className="bg-tertiary-500">
-      <div className="flex divide-x-2 divide-tertiary-500 justify-center bg-white shadow-md rounded-3xl m-5 mb-2 py-20">
-        <div className="flex justify-center w-1/2 flex-col pt-18 px-20 gap-10">
-          {/* title */}
-          <RecipeName
-            name={recipeName}
-            setName={setRecipeName}
-            editMode={editMode}
-          />
-          {/* description */}
-          <RecipeDescription
-            description={recipeDescription}
-            setDescription={setRecipeDescription}
-            editMode={editMode}
-          />
-          <div className="flex flex-wrap gap-2 divide-x">
-            {/* recipeYield */}
-            <RecipeYield
-              recipeYield={yieldAmount}
-              setRecipeYield={setYieldAmount}
-              editMode={editMode}
-            />
-            {/* timeTaken */}
-            <RecipeTimeTaken
-              timeTaken={recipeTotalTime}
-              setTimeTaken={setRecipeTotalTime}
-              editMode={editMode}
-            />
-          </div>
-          {/* Tags */}
-          <div className="flex gap-10 items-center">
-            <Tags
-              tags={recipeTags}
-              setTags={setRecipeTags}
-              editMode={editMode}
-            />
-            {!editMode && (
-              <div className="flex-none self-end">
-              <FavouriteButton recipeId={recipe_id} token={token} size={50}/>
-            </div>   
-            )}     
-          </div>
-        </div>
-        <div className="flex flex-1 flex-col gap-10 justify-center px-20 ">
-          <RecipeImage imageUrl={imageUrl} />
-          <RecipeUrl recipeUrl={recipeUrl} />
-        </div>
-      </div>
-      <div className="h-4 bg-tertiary-500" />
-      <div className="flex justify-center  pb-0">
-        {/* Loop over recipeIngredients array */}
-        <IngredientList
-          recipeIngredients={ingredients}
-          setRecipeIngredients={setIngredients}
-          editMode={editMode}
-        />
-        <InstructionList
-          recipeInstructions={instructions}
-          setRecipeInstructions={setInstructions}
-          editMode={editMode}
-        />
-      </div>
+  const renderPageContent = () => {
+    if (loading) {
+      return <p aria-label="Loading message">Loading ...</p>;
+    }
 
-      {editMode ? (
-        <SaveButton handleSaveRecipe={handleSaveRecipe} />
-      ) : (
-        <EditButton editMode={editMode} setEditMode={setEditMode} />
-      )}
-    </div>
-  );
+    if (
+      error.type === "no-server-response" ||
+      error.type === "unexpected-error"
+    ) {
+      return <p aria-label="error message">{`${error.message}`}</p>;
+    }
+
+    if (
+      !loading &&
+      Object.keys(error).length === 0 &&
+      (!data || data.length === 0)
+    ) {
+      return <p aria-label="Empty Recipes"> No recipe data.</p>;
+    }
+
+    return (
+      <div className="bg-tertiary-500">
+        <div className="flex divide-x-2 divide-tertiary-500 justify-center bg-white shadow-md rounded-3xl m-5 mb-2 py-20">
+          <div className="flex justify-center w-1/2 flex-col pt-18 px-20 gap-10">
+            {/* title */}
+            <RecipeName
+              name={recipeName}
+              setName={setRecipeName}
+              editMode={editMode}
+            />
+            {/* description */}
+            <RecipeDescription
+              description={recipeDescription}
+              setDescription={setRecipeDescription}
+              editMode={editMode}
+            />
+            <div className="flex flex-wrap gap-2 divide-x">
+              {/* recipeYield */}
+              <RecipeYield
+                recipeYield={yieldAmount}
+                setRecipeYield={setYieldAmount}
+                editMode={editMode}
+              />
+              {/* timeTaken */}
+              <RecipeTimeTaken
+                timeTaken={recipeTotalTime}
+                setTimeTaken={setRecipeTotalTime}
+                editMode={editMode}
+              />
+            </div>
+            {/* Tags */}
+            <div className="flex gap-10 items-center">
+              <Tags
+                tags={recipeTags}
+                setTags={setRecipeTags}
+                editMode={editMode}
+              />
+              {!editMode && (
+                <div className="flex-none self-end">
+                  <FavouriteButton
+                    recipeId={recipe_id}
+                    favourited={data.favouritedByOwner}
+                    size={50}
+                  />
+                </div>
+              )}
+            </div>
+          </div>
+          <div className="flex flex-1 flex-col gap-10 justify-center px-20 ">
+            <RecipeImage imageUrl={imageUrl} />
+            <RecipeUrl recipeUrl={recipeUrl} />
+          </div>
+        </div>
+        <div className="h-4 bg-tertiary-500" />
+        <div className="flex justify-center  pb-0">
+          {/* Loop over recipeIngredients array */}
+          <IngredientList
+            recipeIngredients={ingredients}
+            setRecipeIngredients={setIngredients}
+            editMode={editMode}
+          />
+          <InstructionList
+            recipeInstructions={instructions}
+            setRecipeInstructions={setInstructions}
+            editMode={editMode}
+          />
+        </div>
+
+        {editMode ? (
+          <SaveButton handleSaveRecipe={handleSaveRecipe} />
+        ) : (
+          <EditButton editMode={editMode} setEditMode={setEditMode} />
+        )}
+      </div>
+    );
+  };
+
+  return <>{renderPageContent()}</>;
 };

--- a/frontend/tests/components/navBar.test.jsx
+++ b/frontend/tests/components/navBar.test.jsx
@@ -14,15 +14,13 @@ const user = userEvent.setup();
 
 vi.mock("../../src/hooks/useFetchRecipe", () => {
   const useFetchRecipesMock = vi.fn().mockReturnValue({
-    recipes: [],
+    data: [],
     loading: true,
-    error: null,
+    error: {},
     fetchRecipes: vi.fn(),
   });
   return { useFetchRecipes: useFetchRecipesMock };
 });
-
-const setTokenMock = vi.fn();
 
 describe("Navbar", () => {
   describe("When a user is not logged in and on the Home Page:", () => {
@@ -37,7 +35,7 @@ describe("Navbar", () => {
               <Route path="/signup" element={<SignupPage />} />
             </Routes>
           </AuthProvider>
-        </MemoryRouter>
+        </MemoryRouter>,
       );
     });
 

--- a/frontend/tests/hooks/useFetchRecipe.test.js
+++ b/frontend/tests/hooks/useFetchRecipe.test.js
@@ -35,7 +35,7 @@ describe("useFetchRecipe hook:", () => {
     await waitFor(() => {
       expect(axiosPrivateMock.get).toHaveBeenCalledWith("/recipes");
       expect(result.current.loading).toBeFalsy();
-      expect(result.current.error).toBeFalsy();
+      expect(result.current.error).toEqual({});
       expect(result.current.data).toEqual(mockRecipes);
     });
   });

--- a/frontend/tests/pages/MyRecipes/MyRecipesPage.integration.test.jsx
+++ b/frontend/tests/pages/MyRecipes/MyRecipesPage.integration.test.jsx
@@ -1,12 +1,8 @@
 import { act, render, screen } from "@testing-library/react";
 import { vi, describe, test, expect } from "vitest";
 import { MyRecipesPage } from "../../../src/pages/MyRecipes/MyRecipesPage";
-import { CreateRecipePage } from "../../../src/pages/RecipePage/CreateRecipePage";
 import { LoginPage } from "../../../src/pages/Login/LoginPage";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { useFetchRecipes } from "../../../src/hooks/useFetchRecipe";
-import { getAllRecipes, getRecipeById } from "../../../src/services/recipes";
-import { checkToken } from "../../../src/services/authentication";
 import userEvent from "@testing-library/user-event";
 import { SingleRecipePage } from "../../../src/pages/RecipePage/SingleRecipePage";
 import { AuthProvider } from "../../../src/context/AuthProvider";
@@ -24,11 +20,10 @@ const testToken = "testToken";
 const user = userEvent.setup();
 
 describe("When My Recipes Page is first rendered", () => {
-  //TODO: This test failes because RecipeCard is making another FETCH request which overides the mock below
   test("renders fetched recipes", async () => {
     axiosPrivate.get.mockResolvedValue({
       data: {
-        recipes: [
+        data: [
           { _id: 1, name: "test recipe 1", totalTime: 45, image: "test_url" },
           { _id: 2, name: "test recipe 2", totalTime: 30, image: "test_url" },
         ],
@@ -52,7 +47,7 @@ describe("When My Recipes Page is first rendered", () => {
               />
             </Routes>
           </AuthProvider>
-        </MemoryRouter>
+        </MemoryRouter>,
       );
     });
 
@@ -66,7 +61,7 @@ describe("When My Recipes Page is first rendered", () => {
   test("shows a message when recipes is undefined", async () => {
     axiosPrivate.get.mockResolvedValue({
       data: {
-        recipes: undefined,
+        data: undefined,
       },
     });
 
@@ -83,7 +78,7 @@ describe("When My Recipes Page is first rendered", () => {
               />
             </Routes>
           </AuthProvider>
-        </MemoryRouter>
+        </MemoryRouter>,
       );
     });
 
@@ -115,7 +110,7 @@ describe("When My Recipes Page is first rendered", () => {
               />
             </Routes>
           </AuthProvider>
-        </MemoryRouter>
+        </MemoryRouter>,
       );
     });
 
@@ -126,7 +121,7 @@ describe("When My Recipes Page is first rendered", () => {
   test("navigates to login if error during HTTP request", async () => {
     axiosPrivate.get.mockRejectedValue({
       response: {
-        data: { message: "" },
+        status: 401,
       },
     });
 
@@ -148,7 +143,7 @@ describe("When My Recipes Page is first rendered", () => {
               <Route path="/login" element={<LoginPage />} />
             </Routes>
           </AuthProvider>
-        </MemoryRouter>
+        </MemoryRouter>,
       );
     });
     const myRecipesH2El = screen.queryByRole("heading", {
@@ -192,7 +187,7 @@ describe("When My Recipes Page is first rendered", () => {
               <Route path="/login" element={<LoginPage />} />
             </Routes>
           </AuthProvider>
-        </MemoryRouter>
+        </MemoryRouter>,
       );
     });
 
@@ -218,7 +213,7 @@ describe("When My Recipes Page is first rendered", () => {
               <Route path="/login" element={<LoginPage />} />
             </Routes>
           </AuthProvider>
-        </MemoryRouter>
+        </MemoryRouter>,
       );
     });
 
@@ -340,7 +335,7 @@ describe("When a user clicks on:", () => {
               />
             </Routes>
           </AuthProvider>
-        </MemoryRouter>
+        </MemoryRouter>,
       );
     });
 

--- a/frontend/tests/pages/MyRecipes/MyRecipesPage.test.jsx
+++ b/frontend/tests/pages/MyRecipes/MyRecipesPage.test.jsx
@@ -38,19 +38,19 @@ describe("My Recipes Page", () => {
 
   test("renders collection and recipes from db", async () => {
     useFetchRecipes.mockReturnValue({
-      recipes: [
+      data: [
         { _id: "12345", title: "Recipe 1", duration: "45" },
         { _id: "23456", title: "Recipe 2", duration: "60" },
       ],
       loading: false,
-      error: null,
+      error: {},
       fetchRecipes: vi.fn(),
     });
 
     render(
       <AuthProvider>
         <MyRecipesPage />
-      </AuthProvider>
+      </AuthProvider>,
     );
 
     const recipeTitles = screen.getAllByRole("heading", { level: 2 });
@@ -66,14 +66,14 @@ describe("My Recipes Page", () => {
     useFetchRecipes.mockReturnValue({
       recipes: undefined,
       loading: false,
-      error: null,
+      error: {},
       fetchRecipes: vi.fn(),
     });
 
     render(
       <AuthProvider>
         <MyRecipesPage />
-      </AuthProvider>
+      </AuthProvider>,
     );
 
     expect(screen.getByLabelText("Empty Recipes")).toBeVisible();
@@ -83,14 +83,14 @@ describe("My Recipes Page", () => {
     useFetchRecipes.mockReturnValue({
       recipes: [],
       loading: false,
-      error: null,
+      error: {},
       fetchRecipes: vi.fn(),
     });
 
     render(
       <AuthProvider>
         <MyRecipesPage />
-      </AuthProvider>
+      </AuthProvider>,
     );
 
     expect(screen.getByLabelText("Empty Recipes")).toBeVisible();
@@ -100,14 +100,14 @@ describe("My Recipes Page", () => {
     useFetchRecipes.mockReturnValue({
       recipes: [],
       loading: true,
-      error: null,
+      error: {},
       fetchRecipes: vi.fn(),
     });
 
     render(
       <AuthProvider>
         <MyRecipesPage />
-      </AuthProvider>
+      </AuthProvider>,
     );
 
     expect(screen.getByLabelText("Loading message")).toBeVisible();


### PR DESCRIPTION
The original implementation was to have another API request when navigating to the Single Recipe Page. Instead of worrying about caching or efficient use of resources, I felt it was good enough to keep it as it was and make that API request. 

Because of that, I felt like the useFetchRecipes hook could be reused to make the fetch request and for returning state. So the majority of this ticket was to update the hook and rename some variables. The fetchRecipe function now takes a path URL as an arg in comparison to before where only a single path was hardcoded. 
