### PR TITLE
Feature/41/update cors for production

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node src/index.js",
-    "dev": "node --watch -r dotenv/config src/index.js",
+    "dev": "DOTENV_CONFIG_PATH=./.env node --watch -r dotenv/config src/index.js",
     "test": "jest"
   },
   "author": "Makers Academy",

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -13,15 +13,29 @@ const app = express();
 // Allow requests from any client
 // docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
 // docs: https://expressjs.com/en/resources/middleware/cors.html
-app.use(cors({
-  origin: 'http://localhost:5173',
-  credentials: true,
-}));
+
+const whitelist =
+  process.env.NODE_ENV === "production"
+    ? process.env.ALLOWED_ORIGINS.split(",")
+    : ["http://localhost:5173"];
+
+app.use(
+  cors({
+    origin: function (origin, callback) {
+      if (whitelist.indexOf(origin) !== -1 || !origin) {
+        callback(null, true);
+      } else {
+        callback(new Error("Not allowed by CORS"));
+      }
+    },
+    credentials: true,
+  })
+);
 
 // Parse JSON request bodies, made available on `req.body`
 app.use(bodyParser.json());
 
-app.use(cookieParser()); 
+app.use(cookieParser());
 
 // API Routes
 app.use("/users", usersRouter);


### PR DESCRIPTION
## Description:
I had forgot about CORS when I deployed the application on Render. So while the static site and web service was live, they couldn't communicate with each other.
You can check out this #41  issue.

## How:
I refactored app.js in ./api to dynamically retrieve the whitelist urls from env variables based on whether the environment is production or not. 
As there is a possibility the ALLOWED_ORIGINS env variable is a list, I had to update the cors middleware as pointed out by the cors library's documentation.
Read it [here](https://www.npmjs.com/package/cors#configuring-cors-w-dynamic-origin)