### PR TITLE
47/fix/Save recipe without image

### DIFF
--- a/api/src/models/recipe.js
+++ b/api/src/models/recipe.js
@@ -11,7 +11,7 @@ const RecipeSchema = new mongoose.Schema({
   recipeIngredient: [{ type: String, required: true }],
   recipeInstructions: [{ type: String, required: true }],
   url: { type: String, required: false },
-  image: { type: String, required: true },
+  image: { type: String, required: false },
   dateAdded: { type: Date, required: true },
 });
 

--- a/frontend/src/pages/RecipePage/CreateRecipePage.jsx
+++ b/frontend/src/pages/RecipePage/CreateRecipePage.jsx
@@ -64,7 +64,9 @@ export const CreateRecipePage = ({
       yieldAmount === 0 ||
       recipeTotalTime === 0 ||
       ingredients.some((ingredient) => ingredient === "") ||
-      instructions.some((instruction) => instruction === "")
+      ingredients.length === 0 ||
+      instructions.some((instruction) => instruction === "") ||
+      instructions.length === 0
     ) {
       alert("Please fill out all the required fields");
       return;

--- a/frontend/src/pages/RecipePage/SingleRecipePage.jsx
+++ b/frontend/src/pages/RecipePage/SingleRecipePage.jsx
@@ -69,7 +69,9 @@ export const SingleRecipePage = () => {
       yieldAmount === 0 ||
       recipeTotalTime === 0 ||
       ingredients.some((ingredient) => ingredient === "") ||
-      instructions.some((instruction) => instruction === "")
+      !ingredients.length ||
+      instructions.some((instruction) => instruction === "") ||
+      !instructions.length
     ) {
       //TODO:This should really be some Modal.
       alert("Please fill out all the required fields");


### PR DESCRIPTION
## Description:
- Fixed the issue with the user being unable to save their own self-written recipe. 
- Check out issue #47 
- I also fixed the issue of being able to save a recipe that doesn't have any ingredients or instructions.

## Why:
- When users scrape recipes from a page, the script should also be able to get an image for the recipe. 
- However, when a user creates their own recipe, they can't save it as the recipe schema required an image to exist.
- As image upload hasn't been implemented, and there is a possibility that a user doesn't have an image for the recipe, the requirement should be adjusted.
- I think a user shouldn't be able to save a recipe that doesn't have any ingredients or instructions as it could encourage taking up database resources.

## How
- Adjusted Recipe schema to set image requirement to false.
- Created checks for length of ingredients and instructions array to make sure they're populated.
