### PR TITLE
37/feature/scrape recipe error handling

### DIFF
--- a/api/src/controllers/recipes.js
+++ b/api/src/controllers/recipes.js
@@ -253,6 +253,8 @@ const scrapeRecipeFromWebsite = async (req, res) => {
 
     //Once the recipe data has been scraped, we send it to the 'extractRecipeInfo' module to filter out only the data we need.
     const filteredRecipeData = extractRecipeInfo(recipeData);
+    filteredRecipeData.url = url;
+    // console.log(filteredRecipeData);
     res.status(200).json({ recipe_data: filteredRecipeData, token: newToken });
   } catch (error) {
     res.status(500).json({ error: "Internal Server Error" });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,11 +11,6 @@ import { useState } from "react";
 
 const App = () => {
   const [recipeData, setRecipeData] = useState(null);
-  const [url, setUrl] = useState("");
-
-  const handleUrlChange = (e) => {
-    setUrl(e.target.value);
-  };
 
   return (
     <div className="flex flex-col w-screen min-h-screen">
@@ -24,14 +19,7 @@ const App = () => {
         <Routes>
           <Route
             path="/"
-            element={
-              <HomePage
-                url={url}
-                setUrl={setUrl}
-                handleUrlChange={handleUrlChange}
-                setRecipeData={setRecipeData}
-              />
-            }
+            element={<HomePage setRecipeData={setRecipeData} />}
           />
           <Route path="/login" element={<LoginPage />} />
           <Route path="/signup" element={<SignupPage />} />
@@ -41,8 +29,6 @@ const App = () => {
               <CreateRecipePage
                 recipeData={recipeData}
                 setRecipeData={setRecipeData}
-                url={url}
-                setUrl={setUrl}
               />
             }
           />
@@ -53,14 +39,7 @@ const App = () => {
           /> */}
           <Route
             path="/myrecipes"
-            element={
-              <MyRecipesPage
-                url={url}
-                setUrl={setUrl}
-                handleUrlChange={handleUrlChange}
-                setRecipeData={setRecipeData}
-              />
-            }
+            element={<MyRecipesPage setRecipeData={setRecipeData} />}
           />
         </Routes>
       </BrowserRouter>

--- a/frontend/src/components/RecipeScraper.jsx
+++ b/frontend/src/components/RecipeScraper.jsx
@@ -7,26 +7,21 @@ const RecipeScraper = ({ url, setUrl, handleUrlChange, setRecipeData }) => {
   const axiosPrivate = useAxiosPrivate();
   const [errMsg, setErrMsg] = useState("");
 
-  const handleClick = async (manually) => {
-    // Maybe can re-arrange this as clicking "Enter Manually" shouldn't require a try/catch
-    // It might be possible to remove the URL state by having the server return the URL.
-    // That would simplify state management.
+  // It might be possible to remove the URL state by having the server return the URL.
+  // That would simplify state management.
+
+  const handleScrapeRecipe = async () => {
+    if (url === "") {
+      setErrMsg("Please enter a valid URL.");
+      return;
+    }
 
     try {
-      if (!manually) {
-        if (url === "") {
-          setErrMsg("Please enter a valid URL.");
-          return;
-        }
+      const scrapedData = await axiosPrivate.get(
+        `/recipes/scrape?url=${encodeURIComponent(url)}`,
+      );
 
-        const scrapedData = await axiosPrivate.get(
-          `/recipes/scrape?url=${encodeURIComponent(url)}`,
-        );
-        setRecipeData(scrapedData.data.recipe_data);
-      } else {
-        setRecipeData(undefined);
-        setUrl(undefined);
-      }
+      setRecipeData(scrapedData.data.recipe_data);
       navigate("/recipes/create");
     } catch (error) {
       if (error.response && error.response.status === 401) {
@@ -35,6 +30,12 @@ const RecipeScraper = ({ url, setUrl, handleUrlChange, setRecipeData }) => {
         setErrMsg(error.response.data.message);
       }
     }
+  };
+
+  const handleCreateRecipe = () => {
+    setRecipeData(undefined);
+    setUrl(undefined);
+    navigate("/recipes/create");
   };
 
   return (
@@ -53,7 +54,7 @@ const RecipeScraper = ({ url, setUrl, handleUrlChange, setRecipeData }) => {
         <button
           aria-label="Generate"
           onClick={async () => {
-            handleClick(false);
+            handleScrapeRecipe(false);
           }}
           type="button"
           className="shadow-md font-kanit font-bold text-lg text-white bg-secondary-500 hover:bg-blue-900 bg- rounded-lg px-5 py-2"
@@ -64,7 +65,7 @@ const RecipeScraper = ({ url, setUrl, handleUrlChange, setRecipeData }) => {
           aria-label="Manually"
           type="button"
           onClick={async () => {
-            handleClick(true);
+            handleCreateRecipe(true);
           }}
           className="shadow-md font-kanit font-bold text-lg text-primary-500 border border-primary-500 hover:bg-primary-500 hover:text-white rounded-lg px-5 py-2"
         >

--- a/frontend/src/components/RecipeScraper.jsx
+++ b/frontend/src/components/RecipeScraper.jsx
@@ -11,7 +11,7 @@ const RecipeScraper = ({ url, setUrl, handleUrlChange, setRecipeData }) => {
   // That would simplify state management.
 
   const handleScrapeRecipe = async () => {
-    if (url === "") {
+    if (!url) {
       setErrMsg("Please enter a valid URL.");
       return;
     }
@@ -27,14 +27,16 @@ const RecipeScraper = ({ url, setUrl, handleUrlChange, setRecipeData }) => {
       if (error.response && error.response.status === 401) {
         navigate("/login");
       } else {
-        setErrMsg(error.response.data.message);
+        setErrMsg(
+          "There was a problem getting the recipe. Please try again or try a different URL.",
+        );
       }
     }
   };
 
   const handleCreateRecipe = () => {
-    setRecipeData(undefined);
-    setUrl(undefined);
+    setRecipeData(null);
+    setUrl("");
     navigate("/recipes/create");
   };
 

--- a/frontend/src/components/RecipeScraper.jsx
+++ b/frontend/src/components/RecipeScraper.jsx
@@ -32,7 +32,7 @@ const RecipeScraper = ({ url, setUrl, handleUrlChange, setRecipeData }) => {
       if (error.response && error.response.status === 401) {
         navigate("/login");
       } else {
-        console.error(error);
+        setErrMsg(error.response.data.message);
       }
     }
   };

--- a/frontend/src/components/RecipeScraper.jsx
+++ b/frontend/src/components/RecipeScraper.jsx
@@ -2,26 +2,47 @@ import { useNavigate } from "react-router-dom";
 import { useState } from "react";
 import useAxiosPrivate from "../hooks/useAxiosPrivate";
 
-const RecipeScraper = ({ url, setUrl, handleUrlChange, setRecipeData }) => {
+const RecipeScraper = ({ setRecipeData }) => {
   const navigate = useNavigate();
   const axiosPrivate = useAxiosPrivate();
   const [errMsg, setErrMsg] = useState("");
-
+  const [url, setUrl] = useState("");
   // It might be possible to remove the URL state by having the server return the URL.
   // That would simplify state management.
   // It's also probably necessary as otherwise I'd need to left the error message state to App.jsx rather than keeping it in the component.
   // This makes it messy in my opinion.
   // By keeping it in here, I can control the URL state which shouldn't really be handled by a different component.
 
+  //TODO:
+  // I've already made the returned data include url
+  // Need to update tests
+  // Remove url & setURL from App.jsx, HomePage, CreateRecipePage and MyRecipesPage
+  // Need to handle errMsg state in RecipeScraper
+  const handleUrlChange = (e) => {
+    setUrl(e.target.value);
+    setErrMsg("");
+  };
+
+  const validateUrl = (string) => {
+    try {
+      new URL(string);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  };
+
   const handleScrapeRecipe = async () => {
-    if (!url) {
+    const isValidUrl = validateUrl(url);
+    // console.log(isValidUrl);
+    if (!isValidUrl) {
       setErrMsg("Please enter a valid URL.");
       return;
     }
 
     try {
       const scrapedData = await axiosPrivate.get(
-        `/recipes/scrape?url=${encodeURIComponent(url)}`,
+        `/recipes/scrape?url=${encodeURIComponent(url)}`
       );
       // console.log(scrapedData.data.recipe_data.url);
       setRecipeData(scrapedData.data.recipe_data);
@@ -31,7 +52,7 @@ const RecipeScraper = ({ url, setUrl, handleUrlChange, setRecipeData }) => {
         navigate("/login");
       } else {
         setErrMsg(
-          "There was a problem getting the recipe. Please try again or try a different URL.",
+          "There was a problem getting the recipe. Please try again or try a different URL."
         );
       }
     }

--- a/frontend/src/components/RecipeScraper.jsx
+++ b/frontend/src/components/RecipeScraper.jsx
@@ -7,17 +7,7 @@ const RecipeScraper = ({ setRecipeData }) => {
   const axiosPrivate = useAxiosPrivate();
   const [errMsg, setErrMsg] = useState("");
   const [url, setUrl] = useState("");
-  // It might be possible to remove the URL state by having the server return the URL.
-  // That would simplify state management.
-  // It's also probably necessary as otherwise I'd need to left the error message state to App.jsx rather than keeping it in the component.
-  // This makes it messy in my opinion.
-  // By keeping it in here, I can control the URL state which shouldn't really be handled by a different component.
 
-  //TODO:
-  // I've already made the returned data include url
-  // Need to update tests
-  // Remove url & setURL from App.jsx, HomePage, CreateRecipePage and MyRecipesPage
-  // Need to handle errMsg state in RecipeScraper
   const handleUrlChange = (e) => {
     setUrl(e.target.value);
     setErrMsg("");
@@ -42,17 +32,18 @@ const RecipeScraper = ({ setRecipeData }) => {
 
     try {
       const scrapedData = await axiosPrivate.get(
-        `/recipes/scrape?url=${encodeURIComponent(url)}`
+        `/recipes/scrape?url=${encodeURIComponent(url)}`,
       );
       // console.log(scrapedData.data.recipe_data.url);
       setRecipeData(scrapedData.data.recipe_data);
+      setUrl("");
       navigate("/recipes/create");
     } catch (error) {
       if (error.response && error.response.status === 401) {
         navigate("/login");
       } else {
         setErrMsg(
-          "There was a problem getting the recipe. Please try again or try a different URL."
+          "There was a problem getting the recipe. Please try again or try a different URL.",
         );
       }
     }

--- a/frontend/src/components/RecipeScraper.jsx
+++ b/frontend/src/components/RecipeScraper.jsx
@@ -9,6 +9,9 @@ const RecipeScraper = ({ url, setUrl, handleUrlChange, setRecipeData }) => {
 
   // It might be possible to remove the URL state by having the server return the URL.
   // That would simplify state management.
+  // It's also probably necessary as otherwise I'd need to left the error message state to App.jsx rather than keeping it in the component.
+  // This makes it messy in my opinion.
+  // By keeping it in here, I can control the URL state which shouldn't really be handled by a different component.
 
   const handleScrapeRecipe = async () => {
     if (!url) {
@@ -20,7 +23,7 @@ const RecipeScraper = ({ url, setUrl, handleUrlChange, setRecipeData }) => {
       const scrapedData = await axiosPrivate.get(
         `/recipes/scrape?url=${encodeURIComponent(url)}`,
       );
-
+      // console.log(scrapedData.data.recipe_data.url);
       setRecipeData(scrapedData.data.recipe_data);
       navigate("/recipes/create");
     } catch (error) {

--- a/frontend/src/components/RecipeScraper.jsx
+++ b/frontend/src/components/RecipeScraper.jsx
@@ -1,15 +1,21 @@
 import { useNavigate } from "react-router-dom";
+import { useState } from "react";
 import useAxiosPrivate from "../hooks/useAxiosPrivate";
 
 const RecipeScraper = ({ url, setUrl, handleUrlChange, setRecipeData }) => {
   const navigate = useNavigate();
   const axiosPrivate = useAxiosPrivate();
+  const [errMsg, setErrMsg] = useState("");
 
   const handleClick = async (manually) => {
+    // Maybe can re-arrange this as clicking "Enter Manually" shouldn't require a try/catch
+    // It might be possible to remove the URL state by having the server return the URL.
+    // That would simplify state management.
+
     try {
       if (!manually) {
         if (url === "") {
-          console.error("Please input url to scrape recipe");
+          setErrMsg("Please enter a valid URL.");
           return;
         }
 
@@ -40,6 +46,9 @@ const RecipeScraper = ({ url, setUrl, handleUrlChange, setRecipeData }) => {
         className="shadow-md font-poppins font-light w-full border rounded-lg py-2 px-2 focus:ring-1 focus:ring-primary-500 focus:border-primary-500 outline-none"
         placeholder="Enter your recipe url..."
       />
+
+      {errMsg && <p className="text-red-500">{errMsg}</p>}
+
       <div className="flex items-center justify-center py-5 gap-5">
         <button
           aria-label="Generate"

--- a/frontend/src/pages/Home/HomePage.jsx
+++ b/frontend/src/pages/Home/HomePage.jsx
@@ -1,13 +1,6 @@
 import RecipeScraper from "../../components/RecipeScraper";
 
-export const HomePage = ({
-  handleScrapeRecipe,
-  token,
-  url,
-  setUrl,
-  handleUrlChange,
-  setRecipeData,
-}) => {
+export const HomePage = ({ setRecipeData }) => {
   return (
     <div className="flex flex-col justify-center items-center flex-auto">
       <div className="flex justify-center items-center">
@@ -30,14 +23,7 @@ export const HomePage = ({
               generates neatly organised recipes for you to store and access
               anytime, anywhere.
             </p>
-            <RecipeScraper
-              token={token}
-              url={url}
-              setUrl={setUrl}
-              handleUrlChange={handleUrlChange}
-              handleScrapeRecipe={handleScrapeRecipe}
-              setRecipeData={setRecipeData}
-            />
+            <RecipeScraper setRecipeData={setRecipeData} />
           </div>
         </div>
         <div>

--- a/frontend/src/pages/MyRecipes/MyRecipesPage.jsx
+++ b/frontend/src/pages/MyRecipes/MyRecipesPage.jsx
@@ -4,13 +4,7 @@ import { useFetchRecipes } from "../../hooks/useFetchRecipe";
 import RecipeCard from "../../components/Recipe/RecipeCard";
 import RecipeScraper from "../../components/RecipeScraper";
 
-export const MyRecipesPage = ({
-  handleScrapeRecipe,
-  url,
-  setUrl,
-  handleUrlChange,
-  setRecipeData,
-}) => {
+export const MyRecipesPage = ({ setRecipeData }) => {
   const navigate = useNavigate();
   const { data, loading, error, fetchRecipes } = useFetchRecipes();
 
@@ -71,13 +65,7 @@ export const MyRecipesPage = ({
             generates neatly organised recipes for you to store and access
             anytime, anywhere.
           </p>
-          <RecipeScraper
-            url={url}
-            setUrl={setUrl}
-            handleUrlChange={handleUrlChange}
-            handleScrapeRecipe={handleScrapeRecipe}
-            setRecipeData={setRecipeData}
-          />
+          <RecipeScraper setRecipeData={setRecipeData} />
         </div>
       </div>
 

--- a/frontend/src/pages/RecipePage/CreateRecipePage.jsx
+++ b/frontend/src/pages/RecipePage/CreateRecipePage.jsx
@@ -18,8 +18,8 @@ import { EditButton } from "../../components/RecipePage/EditButton";
 export const CreateRecipePage = ({
   recipeData,
   setRecipeData,
-  url,
-  setUrl,
+  // url,
+  // setUrl,
 }) => {
   const navigate = useNavigate();
   const axiosPrivate = useAxiosPrivate();
@@ -33,6 +33,7 @@ export const CreateRecipePage = ({
   const [instructions, setInstructions] = useState([]);
   const [imageUrl, setImageUrl] = useState("");
   const [recipeTags, setRecipeTags] = useState([]);
+  const [url, setUrl] = useState("");
 
   useEffect(() => {
     if (recipeData) {
@@ -45,6 +46,7 @@ export const CreateRecipePage = ({
         recipeIngredient = [],
         recipeInstructions = [],
         image = "",
+        url = "",
       } = recipeData;
 
       setRecipeName(name);
@@ -55,6 +57,7 @@ export const CreateRecipePage = ({
       setInstructions(recipeInstructions);
       setImageUrl(image);
       setRecipeTags(tags);
+      setUrl(url);
     }
   }, [recipeData]);
 

--- a/frontend/src/pages/RecipePage/CreateRecipePage.jsx
+++ b/frontend/src/pages/RecipePage/CreateRecipePage.jsx
@@ -15,12 +15,7 @@ import { RecipeUrl } from "../../components/RecipePage/RecipeFields/RecipeUrl";
 import { SaveButton } from "../../components/RecipePage/SaveButton";
 import { EditButton } from "../../components/RecipePage/EditButton";
 
-export const CreateRecipePage = ({
-  recipeData,
-  setRecipeData,
-  // url,
-  // setUrl,
-}) => {
+export const CreateRecipePage = ({ recipeData, setRecipeData }) => {
   const navigate = useNavigate();
   const axiosPrivate = useAxiosPrivate();
   const [editMode, setEditMode] = useState(true);
@@ -93,9 +88,7 @@ export const CreateRecipePage = ({
     try {
       const response = await axiosPrivate.post("/recipes", data);
       //setRecipeData is set to null so that upon revisit, the page will be empty
-      //Same for setUrl
       setRecipeData(null);
-      setUrl("");
       navigate(`/recipes/${response.data.recipeId}`);
     } catch (err) {
       console.log("Problem saving recipe.");

--- a/frontend/src/pages/Signup/SignupPage.jsx
+++ b/frontend/src/pages/Signup/SignupPage.jsx
@@ -88,7 +88,7 @@ export const SignupPage = () => {
                     onChange={handleUsernameChange}
                   />
                   {formErrors.username && (
-                    <div className="text-red-500">{formErrors.username}</div>
+                    <p className="text-red-500">{formErrors.username}</p>
                   )}
                 </div>
 

--- a/frontend/tests/components/RecipeScraper.test.jsx
+++ b/frontend/tests/components/RecipeScraper.test.jsx
@@ -48,7 +48,7 @@ describe("Unit Test: RecipeScraper", () => {
             handleUrlChange={handleUrlChangeMock}
             setRecipeData={setRecipeDataMock}
           />
-        </AuthProvider>,
+        </AuthProvider>
       );
       const generateRecipeBtn = screen.getByRole("button", {
         name: "Generate",
@@ -68,7 +68,7 @@ describe("Unit Test: RecipeScraper", () => {
             handleUrlChange={handleUrlChangeMock}
             setRecipeData={setRecipeDataMock}
           />
-        </AuthProvider>,
+        </AuthProvider>
       );
       const generateRecipeBtn = screen.getByRole("button", {
         name: "Generate",
@@ -82,7 +82,7 @@ describe("Unit Test: RecipeScraper", () => {
 
   describe("Enter Manually button", () => {
     test("Enter Manually button navigates to create recipe page", async () => {
-      vi.spyOn(authenticationServices, "checkToken").mockResolvedValue(true);
+      vi.spyOn(authenticationServices, "checkToken").mockResolvedValue(true); //Unecessary?
       const navigateMock = useNavigate();
 
       render(
@@ -94,7 +94,7 @@ describe("Unit Test: RecipeScraper", () => {
             handleScrapeRecipe={handleScrapeRecipeMock}
             setRecipeData={setRecipeDataMock}
           />
-        </AuthProvider>,
+        </AuthProvider>
       );
 
       const enterMaunallyBtn = screen.getByRole("button", { name: "Manually" });
@@ -120,7 +120,7 @@ describe("Unit Test: RecipeScraper", () => {
             handleScrapeRecipe={handleScrapeRecipeMock}
             setRecipeData={setRecipeDataMock}
           />
-        </AuthProvider>,
+        </AuthProvider>
       );
 
       const generateRecipeBtn = screen.getByRole("button", {
@@ -130,5 +130,28 @@ describe("Unit Test: RecipeScraper", () => {
 
       expect(navigateMock).toHaveBeenCalledWith("/login");
     });
+  });
+
+  test("Displays validation message for empty URL field", async () => {
+    const navigateMock = useNavigate();
+    render(
+      <AuthProvider>
+        <RecipeScraper
+          url={""}
+          setUrl={setUrlMock}
+          handleUrlChange={handleUrlChangeMock}
+          handleScrapeRecipe={handleScrapeRecipeMock}
+          setRecipeData={setRecipeDataMock}
+        />
+      </AuthProvider>,
+    );
+
+    const generateRecipeBtn = screen.getByRole("button", { name: "Generate" });
+    await userEvent.click(generateRecipeBtn);
+
+    expect(screen.getByText("Please enter a valid URL.")).toBeVisible();
+    //How about having a red ring around it?
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(axiosPrivate.get).not.toHaveBeenCalled();
   });
 });

--- a/frontend/tests/components/RecipeScraper.test.jsx
+++ b/frontend/tests/components/RecipeScraper.test.jsx
@@ -7,11 +7,8 @@ import * as authenticationServices from "../../src/services/authentication";
 import { useNavigate } from "react-router-dom";
 import { AuthProvider } from "../../src/context/AuthProvider.jsx";
 import useAxiosPrivate from "../../src/hooks/useAxiosPrivate.js";
-import Recipe from "../../../api/src/models/recipe.js";
-const handleUrlChangeMock = vi.fn();
 const handleScrapeRecipeMock = vi.fn();
 const setRecipeDataMock = vi.fn();
-const setUrlMock = vi.fn();
 
 // Mocking React Router's useNavigate function
 vi.mock("react-router-dom", () => {
@@ -43,13 +40,8 @@ describe("Unit Test: RecipeScraper", () => {
       const navigateMock = useNavigate();
       render(
         <AuthProvider>
-          <RecipeScraper
-            // url={"www.test-url.com"}
-            // setUrl={setUrlMock}
-            // handleUrlChange={handleUrlChangeMock}
-            setRecipeData={setRecipeDataMock}
-          />
-        </AuthProvider>
+          <RecipeScraper setRecipeData={setRecipeDataMock} />
+        </AuthProvider>,
       );
       const generateRecipeBtn = screen.getByRole("button", {
         name: "Generate",
@@ -68,13 +60,8 @@ describe("Unit Test: RecipeScraper", () => {
       const navigateMock = useNavigate();
       render(
         <AuthProvider>
-          <RecipeScraper
-            // url={""}
-            // setUrl={setUrlMock}
-            // handleUrlChange={handleUrlChangeMock}
-            setRecipeData={setRecipeDataMock}
-          />
-        </AuthProvider>
+          <RecipeScraper setRecipeData={setRecipeDataMock} />
+        </AuthProvider>,
       );
       const generateRecipeBtn = screen.getByRole("button", {
         name: "Generate",
@@ -113,13 +100,7 @@ describe("Unit Test: RecipeScraper", () => {
 
       render(
         <AuthProvider>
-          <RecipeScraper
-            // url={""}
-            // setUrl={setUrlMock}
-            // handleUrlChange={handleUrlChangeMock}
-            // handleScrapeRecipe={handleScrapeRecipeMock}
-            setRecipeData={setRecipeDataMock}
-          />
+          <RecipeScraper setRecipeData={setRecipeDataMock} />
         </AuthProvider>,
       );
 
@@ -139,13 +120,7 @@ describe("Unit Test: RecipeScraper", () => {
 
       render(
         <AuthProvider>
-          <RecipeScraper
-            // url={"www.test-url.com"}
-            // setUrl={setUrlMock}
-            // handleUrlChange={handleUrlChangeMock}
-            // handleScrapeRecipe={handleScrapeRecipeMock}
-            setRecipeData={setRecipeDataMock}
-          />
+          <RecipeScraper setRecipeData={setRecipeDataMock} />
         </AuthProvider>,
       );
 
@@ -163,13 +138,7 @@ describe("Unit Test: RecipeScraper", () => {
       const navigateMock = useNavigate();
       render(
         <AuthProvider>
-          <RecipeScraper
-            // url={""}
-            // setUrl={setUrlMock}
-            // handleUrlChange={handleUrlChangeMock}
-            // handleScrapeRecipe={handleScrapeRecipeMock}
-            setRecipeData={setRecipeDataMock}
-          />
+          <RecipeScraper setRecipeData={setRecipeDataMock} />
         </AuthProvider>,
       );
 
@@ -187,13 +156,7 @@ describe("Unit Test: RecipeScraper", () => {
     test("validation message disappears after entering URL", async () => {
       render(
         <AuthProvider>
-          <RecipeScraper
-            // url={""}
-            // setUrl={setUrlMock}
-            // handleUrlChange={handleUrlChangeMock}
-            // handleScrapeRecipe={handleScrapeRecipeMock}
-            setRecipeData={setRecipeDataMock}
-          />
+          <RecipeScraper setRecipeData={setRecipeDataMock} />
         </AuthProvider>,
       );
 
@@ -223,13 +186,7 @@ describe("Unit Test: RecipeScraper", () => {
       const navigateMock = useNavigate();
       render(
         <AuthProvider>
-          <RecipeScraper
-            // url={"some-url"}
-            // setUrl={setUrlMock}
-            // handleUrlChange={handleUrlChangeMock}
-            // handleScrapeRecipe={handleScrapeRecipeMock}
-            setRecipeData={setRecipeDataMock}
-          />
+          <RecipeScraper setRecipeData={setRecipeDataMock} />
         </AuthProvider>,
       );
 

--- a/frontend/tests/components/RecipeScraper.test.jsx
+++ b/frontend/tests/components/RecipeScraper.test.jsx
@@ -130,28 +130,61 @@ describe("Unit Test: RecipeScraper", () => {
 
       expect(navigateMock).toHaveBeenCalledWith("/login");
     });
-  });
+    test("Displays validation message for empty URL field", async () => {
+      const navigateMock = useNavigate();
+      render(
+        <AuthProvider>
+          <RecipeScraper
+            url={""}
+            setUrl={setUrlMock}
+            handleUrlChange={handleUrlChangeMock}
+            handleScrapeRecipe={handleScrapeRecipeMock}
+            setRecipeData={setRecipeDataMock}
+          />
+        </AuthProvider>,
+      );
 
-  test("Displays validation message for empty URL field", async () => {
-    const navigateMock = useNavigate();
-    render(
-      <AuthProvider>
-        <RecipeScraper
-          url={""}
-          setUrl={setUrlMock}
-          handleUrlChange={handleUrlChangeMock}
-          handleScrapeRecipe={handleScrapeRecipeMock}
-          setRecipeData={setRecipeDataMock}
-        />
-      </AuthProvider>,
-    );
+      const generateRecipeBtn = screen.getByRole("button", {
+        name: "Generate",
+      });
+      await userEvent.click(generateRecipeBtn);
 
-    const generateRecipeBtn = screen.getByRole("button", { name: "Generate" });
-    await userEvent.click(generateRecipeBtn);
+      expect(screen.getByText("Please enter a valid URL.")).toBeVisible();
+      //How about having a red ring around it?
+      expect(navigateMock).not.toHaveBeenCalled();
+      expect(axiosPrivate.get).not.toHaveBeenCalled();
+    });
 
-    expect(screen.getByText("Please enter a valid URL.")).toBeVisible();
-    //How about having a red ring around it?
-    expect(navigateMock).not.toHaveBeenCalled();
-    expect(axiosPrivate.get).not.toHaveBeenCalled();
+    test("Displays error message from API request", async () => {
+      axiosPrivate.get.mockRejectedValue({
+        response: {
+          status: 500,
+          data: { message: "There was a problem getting the recipe." },
+        },
+      });
+
+      const navigateMock = useNavigate();
+      render(
+        <AuthProvider>
+          <RecipeScraper
+            url={"some-url"}
+            setUrl={setUrlMock}
+            handleUrlChange={handleUrlChangeMock}
+            handleScrapeRecipe={handleScrapeRecipeMock}
+            setRecipeData={setRecipeDataMock}
+          />
+        </AuthProvider>,
+      );
+
+      const generateRecipeBtn = screen.getByRole("button", {
+        name: "Generate",
+      });
+      await userEvent.click(generateRecipeBtn);
+
+      expect(
+        screen.getByText("There was a problem getting the recipe.")
+      ).toBeVisible();
+      expect(navigateMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/tests/components/RecipeScraper.test.jsx
+++ b/frontend/tests/components/RecipeScraper.test.jsx
@@ -159,7 +159,7 @@ describe("Unit Test: RecipeScraper", () => {
       axiosPrivate.get.mockRejectedValue({
         response: {
           status: 500,
-          data: { message: "There was a problem getting the recipe." },
+          message: "There was a problem getting the recipe.",
         },
       });
 
@@ -182,7 +182,9 @@ describe("Unit Test: RecipeScraper", () => {
       await userEvent.click(generateRecipeBtn);
 
       expect(
-        screen.getByText("There was a problem getting the recipe.")
+        screen.getByText(
+          "There was a problem getting the recipe. Please try again or try a different URL.",
+        ),
       ).toBeVisible();
       expect(navigateMock).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Description 
- There was no error handling for empty url string and error response from server.
- See  #37. 
- I also noticed having a url state over complicated state management on the frontend and we could just have the server return the url of the scraped recipe. 

## Why:
- When testing URLs, I noticed that the user could not know when there was an error. That's why an appropriate message needs to be displayed.
- Whilst adding the error message, I noticed that we kept the URL state on the frontend. The purpose was to send the URL string to the correct page for saving together with the recipe. This introduced unnecessary state management and more tightly coupled components. 

## How:
- I refactored the on-click handler function into 2 separate handlers for each button.
- I added a validation check for URL string.
- I removed [url, setUrl] and handleScrapeRecipe from the RecipeScraper component and localised them.
- Doing that allowed me to create a local error message state for the component.
- I made the API return the URL string along with the recipe data so that the frontend didn't need to keep track of a URL state.
- This allowed me to remove all URL state handlers from App.jsx and other pages/components, simplifying state management.
- I updated tests for RecipeScraper and MyRecipesPage.