### PR TITLE
Feat/52/auto log in

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,10 +7,29 @@ import { SingleRecipePage } from "./pages/RecipePage/SingleRecipePage";
 import { CreateRecipePage } from "./pages/RecipePage/CreateRecipePage";
 import { MyRecipesPage } from "./pages/MyRecipes/MyRecipesPage";
 import Navbar from "./components/Navbar";
-import { useState } from "react";
-
+import { useState, useEffect } from "react";
+import { refresh } from "./services/authentication";
+import useAuth from "./hooks/useAuth";
 const App = () => {
+  const { setAuth } = useAuth();
   const [recipeData, setRecipeData] = useState(null);
+
+  useEffect(() => {
+    const refreshAccessToken = async () => {
+      const result = await refresh();
+
+      if (!result.success) {
+        setAuth({});
+        return;
+      }
+
+      setAuth((prev) => {
+        return { ...prev, token: result.response.data.token };
+      });
+    };
+
+    refreshAccessToken();
+  }, [setAuth]);
 
   return (
     <div className="flex flex-col w-screen min-h-screen">

--- a/frontend/src/api/axios.js
+++ b/frontend/src/api/axios.js
@@ -4,7 +4,7 @@ const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
 export const axiosPublic = axios.create({
   baseURL: BACKEND_URL || "https://localhost:3000",
   headers: { "Content-Type": "application/json" },
-  // withCredentials: true,
+  withCredentials: true,
 });
 
 export const axiosPrivate = axios.create({

--- a/frontend/src/pages/Login/LoginPage.jsx
+++ b/frontend/src/pages/Login/LoginPage.jsx
@@ -82,7 +82,7 @@ export const LoginPage = () => {
                     name="username"
                     id="username"
                     className="outline-none focus:ring-1 bg-gray-50 border border-gray-300 text-gray-900 sm:text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5"
-                    placeholder="name@domain.com"
+                    placeholder=""
                     value={username}
                     onChange={handleusernameChange}
                   />

--- a/frontend/src/services/authentication.js
+++ b/frontend/src/services/authentication.js
@@ -14,8 +14,7 @@ const LOGIN_URL = "/tokens";
  */
 
 /**
- * @description - Takes a username and password param and makes a fetch request.
- * @async
+ * @description Takes a username and password param and makes a fetch request.
  * @param {string} username - The username of the user.
  * @param {string} password - The password of the user.
  * @returns {Promise<PromiseResponse>} A promise that resolves to an object indicating the success status and user authentication or error information.
@@ -33,8 +32,12 @@ export const logIn = async (username, password) => {
   return res;
 };
 
+/**
+ * @description Uses the http-only cookie to retrieve a JWT access token.
+ * @returns {Promise<PromiseResponse>}
+ */
 export const refresh = async () => {
-  const res = await promiseHandler(axiosPrivate.post("/tokens/refresh"));
+  const res = await promiseHandler(axiosPublic.post("/tokens/refresh"));
   return res;
 };
 

--- a/frontend/src/services/authentication.js
+++ b/frontend/src/services/authentication.js
@@ -17,7 +17,7 @@ const LOGIN_URL = "/tokens";
  * @description Takes a username and password param and makes a fetch request.
  * @param {string} username - The username of the user.
  * @param {string} password - The password of the user.
- * @returns {Promise<PromiseResponse>} A promise that resolves to an object indicating the success status and user authentication or error information.
+ * @returns {Promise<PromiseResponse>} A promise that resolves to an object indicating the success status, and user's access JWT or error information.
  */
 export const logIn = async (username, password) => {
   if (!username || !password) {
@@ -34,13 +34,16 @@ export const logIn = async (username, password) => {
 
 /**
  * @description Uses the http-only cookie to retrieve a JWT access token.
- * @returns {Promise<PromiseResponse>}
+ * @returns {Promise<PromiseResponse>} A promise that resolves to an object indicating the success status, and a user's access JWT or error information.
  */
 export const refresh = async () => {
   const res = await promiseHandler(axiosPublic.post("/tokens/refresh"));
   return res;
 };
 
+/**
+ * @description Sends a request to the logout endpoint to clear the refresh JWT stored inside the http-only cookie resulting in "logging out".
+ * @returns {Promise<PromiseResponse} A promise that resolves to an object with a message about succesful log out or an error message.*/
 export const logOut = async () => {
   const res = await promiseHandler(axiosPrivate.post("/tokens/logout"));
   return res;

--- a/frontend/src/services/promiseHandler.js
+++ b/frontend/src/services/promiseHandler.js
@@ -21,7 +21,7 @@ export async function promiseHandler(promise) {
   } catch (error) {
     const errMessage = error.response
       ? error.response.data?.message
-      : "An unexpected error occured. Please check internet connection or try again later.";
+      : "An unexpected error occurred. Please check your internet connection or try again later.";
     return { success: false, error: { message: errMessage } };
   }
 }

--- a/frontend/tests/services/authentication.test.js
+++ b/frontend/tests/services/authentication.test.js
@@ -78,8 +78,8 @@ describe("authentication service", () => {
 
       await refresh();
 
-      expect(axiosPrivate.post).toHaveBeenCalledOnce();
-      expect(axiosPrivate.post).toHaveBeenCalledWith("/tokens/refresh");
+      expect(axiosPublic.post).toHaveBeenCalledOnce();
+      expect(axiosPublic.post).toHaveBeenCalledWith("/tokens/refresh");
       // This is an array of the arguments that were last passed to fetch
       // const fetchArguments = fetch.mock.lastCall;
       // const url = fetchArguments[0];
@@ -91,7 +91,7 @@ describe("authentication service", () => {
     });
 
     it("returns a success object with an access token if the request was successful", async () => {
-      axiosPrivate.post.mockResolvedValue({
+      axiosPublic.post.mockResolvedValue({
         data: { token: "jwt-token", message: "Access token issued." },
       });
 
@@ -106,7 +106,7 @@ describe("authentication service", () => {
     });
 
     it("returns an error object if the request failed", async () => {
-      axiosPrivate.post.mockRejectedValue({
+      axiosPublic.post.mockRejectedValue({
         response: {
           data: { message: "Unauthorised" },
         },
@@ -152,7 +152,7 @@ describe("authentication service", () => {
         success: false,
         error: {
           message:
-            "An unexpected error occured. Please check internet connection or try again later.",
+            "An unexpected error occurred. Please check your internet connection or try again later.",
         },
       });
     });


### PR DESCRIPTION
## Description:
- If a user refreshes the page, the login state would be cleared despite being "logged in".
- See issue #52 

## Why:
- To make the user experience better, the user should stay logged in even if they refresh the page. 

## How:
- My idea was to have the app attempt to use a refresh token to automatically log in by making a request upon loading.
- If the cookie does exist and the refresh token is valid, then the api would return an access JWT and set it in state.
- The drawback of this approach is that a network request will always be made when first opening the app or when refreshing even if there isn't a http-only cookie. That would be the cost for useability. 
- I also found that the cookie wasn't correctly being stored in the browser as "withCredentials: true" wasn't set so I corrected it.
- I also took this opportunity to add some documentation to the authentication service with JSDoc.